### PR TITLE
Re-attach opencode sessions on first event after resume

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "build": "tsc -p tsconfig.json",
     "check": "tsc -p tsconfig.json --noEmit",
     "daemon": "tsx src/daemon/index.ts",
-    "test": "node --import tsx --test src/daemon/github/diff.test.ts src/daemon/github/graphql.test.ts src/daemon/github/http.test.ts src/daemon/github/ratelimit.test.ts src/daemon/persistence/store.test.ts src/daemon/watchers/adaptive-schedule.test.ts src/daemon/watchers/disable-gate.test.ts src/daemon/watchers/integration.test.ts src/daemon/watchers/poll-scheduler.test.ts src/daemon/reminders/detail-files.test.ts src/plugin/__tests__/commands.test.ts src/plugin/__tests__/compatibility.test.ts src/plugin/__tests__/debug-state.test.ts src/plugin/__tests__/idle-delivery.test.ts src/plugin/__tests__/packaging.test.ts",
+    "test": "node --import tsx --test src/daemon/github/diff.test.ts src/daemon/github/graphql.test.ts src/daemon/github/http.test.ts src/daemon/github/ratelimit.test.ts src/daemon/persistence/store.test.ts src/daemon/watchers/adaptive-schedule.test.ts src/daemon/watchers/disable-gate.test.ts src/daemon/watchers/integration.test.ts src/daemon/watchers/poll-scheduler.test.ts src/daemon/reminders/detail-files.test.ts src/plugin/__tests__/commands.test.ts src/plugin/__tests__/compatibility.test.ts src/plugin/__tests__/debug-state.test.ts src/plugin/__tests__/idle-delivery.test.ts src/plugin/__tests__/packaging.test.ts src/plugin/__tests__/reattach.test.ts",
     "test:compat": "node --import tsx --test src/plugin/__tests__/compatibility.test.ts",
     "test:live": "node --import tsx src/test/live-validation.ts",
     "test:live:contract": "node --import tsx src/test/live-validation.ts --contract-only"

--- a/src/daemon/ipc/router.ts
+++ b/src/daemon/ipc/router.ts
@@ -1,9 +1,12 @@
 import { PREMIND_CLIENT_HEARTBEAT_MS, PREMIND_CLIENT_LEASE_TTL_MS, PREMIND_IDLE_SHUTDOWN_GRACE_MS } from "../../shared/constants.ts"
 import { debugStatusResponseSchema, type AckReminderPayload, type RegisterClientPayload } from "../../shared/schema.ts"
 import type { PremindRequest, PremindResponse } from "../../shared/ipc.ts"
+import { createLogger } from "../logging/logger.ts"
 import { StateStore } from "../persistence/store.ts"
 
 export class Router {
+  private readonly logger = createLogger("daemon.ipc")
+
   constructor(private readonly store: StateStore) {}
 
   handle(request: PremindRequest): PremindResponse {
@@ -18,9 +21,16 @@ export class Router {
       case "releaseClient":
         this.store.releaseClient(request.payload.clientId)
         return this.ok({ released: true })
-      case "registerSession":
-        this.store.registerSession(request.payload)
-        return this.ok({ registered: true })
+      case "registerSession": {
+        const { created } = this.store.registerSession(request.payload)
+        this.logger.info(created ? "session registered" : "session re-registered", {
+          sessionId: request.payload.sessionId,
+          repo: request.payload.repo,
+          branch: request.payload.branch,
+          reattach: !created,
+        })
+        return this.ok({ registered: true, created })
+      }
       case "updateSessionState": {
         const updated = this.store.updateSessionState(request.payload)
         if (!updated) return this.fail("SESSION_NOT_FOUND", `Unknown session: ${request.payload.sessionId}`)

--- a/src/daemon/persistence/store.test.ts
+++ b/src/daemon/persistence/store.test.ts
@@ -667,4 +667,163 @@ describe("StateStore", () => {
     assert.equal(store.getLastReapCount(), 1)
     store.close()
   })
+
+  test("registerSession returns {created: true} for a fresh row", () => {
+    const store = createStore()
+    store.registerClient("client-re-1", { pid: 1, projectRoot: "/tmp/project" })
+
+    const result = store.registerSession({
+      clientId: "client-re-1",
+      sessionId: "session-fresh",
+      repo: "acme/repo",
+      branch: "feature/fresh",
+      isPrimary: true,
+      status: "active",
+      busyState: "idle",
+    })
+    assert.deepEqual(result, { created: true })
+
+    store.close()
+  })
+
+  test("registerSession returns {created: false} when re-registering the same session", () => {
+    const store = createStore()
+    store.registerClient("client-re-2", { pid: 2, projectRoot: "/tmp/project" })
+
+    const first = store.registerSession({
+      clientId: "client-re-2",
+      sessionId: "session-reattach",
+      repo: "acme/repo",
+      branch: "feature/reattach",
+      isPrimary: true,
+      status: "active",
+      busyState: "idle",
+    })
+    assert.deepEqual(first, { created: true })
+
+    const second = store.registerSession({
+      clientId: "client-re-2",
+      sessionId: "session-reattach",
+      repo: "acme/repo",
+      branch: "feature/reattach",
+      isPrimary: true,
+      status: "active",
+      busyState: "idle",
+    })
+    assert.deepEqual(second, { created: false })
+
+    store.close()
+  })
+
+  test("recordBranchAssociation on fresh PR with existing events skips replay by advancing cursor", () => {
+    const store = createStore()
+    store.registerClient("client-re-3", { pid: 3, projectRoot: "/tmp/project" })
+
+    // Simulate a prior daemon run having recorded events for PR #42. The session does
+    // not yet exist — these events are historical from the perspective of the session
+    // we're about to attach.
+    store.recordBranchAssociation("acme/repo", "feature/skip-replay", 42)
+    store.insertEvents("acme/repo", 42, [
+      {
+        dedupeKey: "event-1",
+        kind: "issue_comment.created",
+        priority: "high",
+        summary: "Historical event 1",
+        payload: {},
+      },
+      {
+        dedupeKey: "event-2",
+        kind: "issue_comment.created",
+        priority: "high",
+        summary: "Historical event 2",
+        payload: {},
+      },
+    ])
+
+    // Now attach a fresh session to the same branch; recordBranchAssociation runs again
+    // as part of the discovery path.
+    store.registerSession({
+      clientId: "client-re-3",
+      sessionId: "session-skip-replay",
+      repo: "acme/repo",
+      branch: "feature/skip-replay",
+      isPrimary: true,
+      status: "active",
+      busyState: "idle",
+    })
+    store.recordBranchAssociation("acme/repo", "feature/skip-replay", 42)
+
+    // Build a reminder batch — historical events should have been skipped.
+    assert.equal(store.buildReminderBatch("session-skip-replay"), null)
+
+    // New events after association should deliver normally.
+    store.insertEvents("acme/repo", 42, [
+      {
+        dedupeKey: "event-3",
+        kind: "issue_comment.created",
+        priority: "high",
+        summary: "Fresh event after attach",
+        payload: {},
+      },
+    ])
+    const batch = store.buildReminderBatch("session-skip-replay")
+    assert.ok(batch)
+    assert.equal(batch.events.length, 1)
+    assert.equal(batch.events[0].summary, "Fresh event after attach")
+
+    store.close()
+  })
+
+  test("recordBranchAssociation does NOT reset cursor on idempotent re-association", () => {
+    const store = createStore()
+    store.registerClient("client-re-4", { pid: 4, projectRoot: "/tmp/project" })
+
+    store.registerSession({
+      clientId: "client-re-4",
+      sessionId: "session-idempotent",
+      repo: "acme/repo",
+      branch: "feature/idempotent",
+      isPrimary: true,
+      status: "active",
+      busyState: "idle",
+    })
+    store.recordBranchAssociation("acme/repo", "feature/idempotent", 7)
+
+    // Deliver and confirm an event; cursor should advance via ack.
+    store.insertEvents("acme/repo", 7, [
+      {
+        dedupeKey: "evt-a",
+        kind: "issue_comment.created",
+        priority: "high",
+        summary: "Real delivered event",
+        payload: {},
+      },
+    ])
+    const batch = store.buildReminderBatch("session-idempotent")
+    assert.ok(batch)
+    store.ackReminder({
+      batchId: batch!.batchId,
+      sessionId: "session-idempotent",
+      state: "confirmed",
+    })
+
+    // Re-running association with the same PR must NOT roll the cursor backwards or
+    // forwards; subsequent new events must still be delivered.
+    store.recordBranchAssociation("acme/repo", "feature/idempotent", 7)
+    store.insertEvents("acme/repo", 7, [
+      {
+        dedupeKey: "evt-b",
+        kind: "issue_comment.created",
+        priority: "high",
+        summary: "Next event after re-association",
+        payload: {},
+      },
+    ])
+    const nextBatch = store.buildReminderBatch("session-idempotent")
+    assert.ok(nextBatch)
+    assert.equal(nextBatch.events.length, 1)
+    assert.equal(nextBatch.events[0].summary, "Next event after re-association")
+
+    store.close()
+  })
 })

--- a/src/daemon/persistence/store.ts
+++ b/src/daemon/persistence/store.ts
@@ -137,7 +137,8 @@ export class StateStore {
     this.db.prepare(`DELETE FROM client_leases WHERE expires_at <= ?`).run(now)
   }
 
-  registerSession(payload: RegisterSessionPayload, now = Date.now()) {
+  registerSession(payload: RegisterSessionPayload, now = Date.now()): { created: boolean } {
+    const existing = this.getSession(payload.sessionId)
     this.db
       .prepare(
         `
@@ -160,6 +161,7 @@ export class StateStore {
         now,
       })
     this.touchBranchWatcher(payload.repo, payload.branch, now)
+    return { created: !existing }
   }
 
   updateSessionState(payload: UpdateSessionStatePayload, now = Date.now()) {
@@ -362,9 +364,39 @@ export class StateStore {
       )
       .run({ repo, branch, prNumber, checkedAt })
 
+    // Find sessions whose pr_number is about to change. For any session that is newly
+    // associated with a PR (or switched to a different PR), fast-forward its delivery
+    // cursor past any pre-existing events for that PR. This prevents replaying history
+    // the user has either already seen (re-attach case) or never saw but wouldn't want
+    // dumped at once (stale event log).
+    const sessionsToUpdate = this.db
+      .prepare(
+        `SELECT session_id, pr_number FROM sessions WHERE repo = :repo AND branch = :branch`,
+      )
+      .all({ repo, branch }) as Array<{ session_id: string; pr_number: number | null }>
+
+    let freshCursor = 0
+    if (prNumber !== null) {
+      const row = this.db
+        .prepare(`SELECT MAX(seq) AS maxSeq FROM pr_events WHERE repo = :repo AND pr_number = :prNumber`)
+        .get({ repo, prNumber }) as { maxSeq: number | null } | undefined
+      freshCursor = row?.maxSeq ?? 0
+    }
+
     this.db
       .prepare(`UPDATE sessions SET pr_number = :prNumber, updated_at = :checkedAt WHERE repo = :repo AND branch = :branch`)
       .run({ repo, branch, prNumber, checkedAt })
+
+    if (prNumber !== null && freshCursor > 0) {
+      const advance = this.db.prepare(
+        `UPDATE sessions SET last_delivered_event_seq = :cursor WHERE session_id = :sessionId`,
+      )
+      for (const session of sessionsToUpdate) {
+        if (session.pr_number !== prNumber) {
+          advance.run({ cursor: freshCursor, sessionId: session.session_id })
+        }
+      }
+    }
 
     if (prNumber !== null) {
       this.touchPrWatcher(repo, prNumber, checkedAt)

--- a/src/plugin/__tests__/reattach.test.ts
+++ b/src/plugin/__tests__/reattach.test.ts
@@ -1,0 +1,200 @@
+import assert from "node:assert/strict"
+import { describe, test } from "node:test"
+import { createPremindPlugin } from "../index.ts"
+
+// ---------------------------------------------------------------------------
+// Harness: a daemon that simulates "session unknown" until registerSession runs.
+// ---------------------------------------------------------------------------
+
+type OperationLog = string[]
+
+const makeReattachingDaemon = (knownSessionIds: Set<string> = new Set()) => {
+  const operations: OperationLog = []
+
+  const requireKnown = (sessionId: string, op: string) => {
+    operations.push(`${op}:${sessionId}`)
+    if (!knownSessionIds.has(sessionId)) {
+      throw new Error(`SESSION_NOT_FOUND: unknown session ${sessionId}`)
+    }
+  }
+
+  const daemon = {
+    registerClient: async () => ({ heartbeatMs: 10_000, leaseTtlMs: 30_000, idleShutdownGraceMs: 15_000 }),
+    heartbeat: async () => undefined,
+    release: async () => undefined,
+    registerSession: async ({ sessionId }: { sessionId: string }) => {
+      operations.push(`register:${sessionId}`)
+      knownSessionIds.add(sessionId)
+    },
+    updateSessionState: async ({ sessionId, busyState }: { sessionId: string; busyState?: string }) => {
+      requireKnown(sessionId, `update:${busyState ?? "none"}`)
+    },
+    unregisterSession: async (sessionId: string) => {
+      operations.push(`unregister:${sessionId}`)
+      knownSessionIds.delete(sessionId)
+    },
+    pauseSession: async (sessionId: string) => {
+      requireKnown(sessionId, "pause")
+    },
+    resumeSession: async (sessionId: string) => {
+      requireKnown(sessionId, "resume")
+    },
+    getPendingReminder: async (_sessionId: string) => ({ batch: null }),
+    ackReminder: async () => undefined,
+    setGlobalDisabled: async (disabled: boolean) => ({ disabled }),
+    getGlobalDisabled: async () => ({ disabled: false }),
+    debugStatus: async () => ({
+      daemon: { protocolVersion: 1, heartbeatMs: 10_000, leaseTtlMs: 30_000, idleShutdownGraceMs: 15_000 },
+      activeClients: 1,
+      activeSessions: knownSessionIds.size,
+      activeWatchers: 0,
+      lastReapAt: null,
+      lastReapCount: 0,
+      sessions: [],
+    }),
+    _operations: operations,
+    _knownSessionIds: knownSessionIds,
+  }
+
+  return daemon
+}
+
+const makePlugin = async (
+  daemon: ReturnType<typeof makeReattachingDaemon>,
+  sessionGet: (id: string) => { data: { parentID?: string } } = () => ({ data: {} }),
+) => {
+  const plugin = await createPremindPlugin({
+    createDaemonClient: () => daemon as never,
+    detectGit: async () => ({ repo: "acme/repo", branch: "feature/reattach" }),
+    ensureDaemon: async () => {},
+    idleDeliveryThresholdMs: 0,
+  })({
+    directory: "/tmp/project",
+    worktree: "/tmp/project",
+    client: {
+      session: {
+        get: async ({ path }: { path: { id: string } }) => sessionGet(path.id),
+        prompt: async () => {},
+        promptAsync: async () => {},
+      },
+      tui: {
+        showToast: async () => undefined,
+      },
+    },
+  } as never)
+
+  const runtime = plugin as unknown as {
+    config: (input: Record<string, unknown>) => Promise<void>
+    event: (input: { event: unknown }) => Promise<void>
+    "chat.message": (input: unknown, output: unknown) => Promise<void>
+    tool: Record<string, { execute: (args: unknown, ctx: unknown) => Promise<string> }>
+  }
+  await runtime.config({})
+  return runtime
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("reactive session re-attach", () => {
+  test("chat.message on unknown session triggers re-attach then retries busy update", async () => {
+    // Daemon starts with no known sessions.
+    const daemon = makeReattachingDaemon(new Set())
+    const runtime = await makePlugin(daemon)
+
+    // No session.created event is fired — session was 'resumed' from a prior opencode process.
+    // A user sends a chat message on this resumed session.
+    await runtime["chat.message"](
+      { sessionID: "resumed-session" },
+      { message: { parts: [{ type: "text", text: "hello" }] }, parts: [] },
+    )
+
+    // Expected sequence:
+    // 1. first busy update fails (SESSION_NOT_FOUND)
+    // 2. withReattach calls registerSession
+    // 3. retry the busy update — succeeds
+    assert.deepEqual(daemon._operations, [
+      "update:busy:resumed-session",
+      "register:resumed-session",
+      "update:busy:resumed-session",
+    ])
+  })
+
+  test("session.idle on unknown session triggers re-attach then retries idle update", async () => {
+    const daemon = makeReattachingDaemon(new Set())
+    const runtime = await makePlugin(daemon)
+
+    await runtime.event({ event: { type: "session.idle", properties: { sessionID: "resumed-session" } } })
+
+    assert.deepEqual(daemon._operations, [
+      "update:idle:resumed-session",
+      "register:resumed-session",
+      "update:idle:resumed-session",
+    ])
+  })
+
+  test("session.status busy on unknown session triggers re-attach", async () => {
+    const daemon = makeReattachingDaemon(new Set())
+    const runtime = await makePlugin(daemon)
+
+    await runtime.event({
+      event: {
+        type: "session.status",
+        properties: { sessionID: "resumed-session", status: { type: "busy" } },
+      },
+    })
+
+    assert.deepEqual(daemon._operations, [
+      "update:busy:resumed-session",
+      "register:resumed-session",
+      "update:busy:resumed-session",
+    ])
+  })
+
+  test("known session does NOT trigger a redundant re-attach", async () => {
+    // Daemon already knows about this session (simulating session.created fired earlier).
+    const daemon = makeReattachingDaemon(new Set(["already-known"]))
+    const runtime = await makePlugin(daemon)
+
+    await runtime["chat.message"](
+      { sessionID: "already-known" },
+      { message: { parts: [{ type: "text", text: "hello" }] }, parts: [] },
+    )
+
+    // Only the busy update should have fired. No spurious registerSession.
+    assert.deepEqual(daemon._operations, ["update:busy:already-known"])
+  })
+
+  test("child session (parentID set) is not re-attached even on chat.message", async () => {
+    const daemon = makeReattachingDaemon(new Set())
+    const runtime = await makePlugin(daemon, () => ({ data: { parentID: "parent-123" } }))
+
+    await runtime["chat.message"](
+      { sessionID: "child-session" },
+      { message: { parts: [{ type: "text", text: "hello" }] }, parts: [] },
+    )
+
+    // Expected: update fails SESSION_NOT_FOUND, attachSession runs but bails (parentID),
+    // so no registerSession. Retry is not attempted after attach bail-out.
+    // We should see the initial update attempt, but NO register and NO retry.
+    assert.deepEqual(daemon._operations, ["update:busy:child-session"])
+    assert.equal(daemon._knownSessionIds.size, 0, "child session must not be registered")
+  })
+
+  test("/premind-pause on unknown session re-attaches and pauses", async () => {
+    const daemon = makeReattachingDaemon(new Set())
+    const runtime = await makePlugin(daemon)
+
+    // Invoke the pause command via the tool to bypass the chat.message marker flow.
+    const result = await runtime.tool.premind_pause.execute({}, { sessionID: "resumed-session" })
+    assert.match(result, /premind paused/)
+
+    // Sequence: pause fails, re-attach, pause retried successfully.
+    assert.deepEqual(daemon._operations, [
+      "pause:resumed-session",
+      "register:resumed-session",
+      "pause:resumed-session",
+    ])
+  })
+})

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -143,11 +143,13 @@ export const createPremindPlugin = (dependencies: PremindPluginDependencies = {}
   }, lease.heartbeatMs ?? PREMIND_CLIENT_HEARTBEAT_MS)
   if (typeof heartbeat.unref === "function") heartbeat.unref()
 
-  const attachSession = async (sessionID: string) => {
+  const attachSession = async (sessionID: string, trigger: "created" | "reattach" = "created"): Promise<boolean> => {
     const session = await client.session.get({ path: { id: sessionID } })
     const sessionData = session.data
     const git = await gitDetector(root)
-    if (sessionData?.parentID) return
+    // Premind only tracks primary (non-child) sessions. Child sessions (subagent,
+    // task, etc.) inherit their parent's reminder stream via the parent session.
+    if (sessionData?.parentID) return false
 
     await daemon.registerSession({
       sessionId: sessionID,
@@ -158,11 +160,57 @@ export const createPremindPlugin = (dependencies: PremindPluginDependencies = {}
       busyState: "idle",
     })
     lastPrimarySessionId = sessionID
-    writePluginRuntimeState({ phase: "session-attached", lastSessionId: sessionID })
+    writePluginRuntimeState({
+      phase: trigger === "reattach" ? "session-reattached" : "session-attached",
+      lastSessionId: sessionID,
+    })
+    return true
   }
 
   const isSessionNotFound = (error: unknown) =>
     error instanceof Error && error.message.startsWith("SESSION_NOT_FOUND")
+
+  // Reactive re-attach: when a daemon call reports SESSION_NOT_FOUND for a session
+  // the plugin DID observe an opencode event for, the session almost certainly
+  // exists in opencode but not in premind's DB (e.g. opencode resumed a past
+  // session, or the daemon's DB was wiped). Re-attach and retry once.
+  //
+  // Returns true if the initial call or retry succeeded. Returns false if the
+  // session is a child session (attachSession deliberately skips parented sessions)
+  // or if re-attach itself failed. Callers can use the boolean to decide whether
+  // to continue with session-scoped bookkeeping.
+  const withReattach = async (sessionID: string, fn: () => Promise<unknown>): Promise<boolean> => {
+    try {
+      await fn()
+      return true
+    } catch (error) {
+      if (!isSessionNotFound(error)) throw error
+      let attached: boolean
+      try {
+        attached = await attachSession(sessionID, "reattach")
+      } catch (attachError) {
+        writePluginRuntimeState({
+          phase: "session-reattach-failed",
+          lastSessionId: sessionID,
+          error: attachError instanceof Error ? attachError.message : String(attachError),
+        })
+        return false
+      }
+      // attachSession returns false when the session is a child (parentID set) —
+      // don't retry; premind intentionally ignores child sessions.
+      if (!attached) return false
+      try {
+        await fn()
+        return true
+      } catch (retryError) {
+        // If the retry still hits SESSION_NOT_FOUND, something raced (e.g. the
+        // session was unregistered between our registerSession and the retry).
+        // Swallow quietly.
+        if (isSessionNotFound(retryError)) return false
+        throw retryError
+      }
+    }
+  }
 
   // Attempt immediate delivery of a pending reminder for a session.
   // Does nothing if no batch exists or if one is already in-flight.
@@ -364,13 +412,12 @@ export const createPremindPlugin = (dependencies: PremindPluginDependencies = {}
 
   const handleSessionIdle = async (sessionID: string) => {
     const git = await gitDetector(root)
-    try {
-      await daemon.updateSessionState({ sessionId: sessionID, busyState: "idle", repo: git.repo, branch: git.branch })
-    } catch (error) {
-      // Session may not be registered (e.g. child session, or created event missed). Skip silently.
-      if (isSessionNotFound(error)) return
-      throw error
-    }
+    const ok = await withReattach(sessionID, () =>
+      daemon.updateSessionState({ sessionId: sessionID, busyState: "idle", repo: git.repo, branch: git.branch }),
+    )
+    // withReattach returns false if the session is a child (attachSession bailed)
+    // or if re-attach itself failed; in either case there is no idle state to manage.
+    if (!ok) return
 
     // Record idle start time if not already set, then schedule threshold-based delivery.
     if (!idleSince.has(sessionID)) {
@@ -407,12 +454,12 @@ export const createPremindPlugin = (dependencies: PremindPluginDependencies = {}
   }
 
   const handlePauseCommand = async (sessionID: string, inputRef?: { agent?: string; model?: { providerID: string; modelID: string } }) => {
-    await daemon.pauseSession(sessionID)
+    await withReattach(sessionID, () => daemon.pauseSession(sessionID))
     await injectResponse(sessionID, `premind paused for session ${sessionID}`, inputRef)
   }
 
   const handleResumeCommand = async (sessionID: string, inputRef?: { agent?: string; model?: { providerID: string; modelID: string } }) => {
-    await daemon.resumeSession(sessionID)
+    await withReattach(sessionID, () => daemon.resumeSession(sessionID))
     await injectResponse(sessionID, `premind resumed for session ${sessionID}`, inputRef)
   }
 
@@ -501,7 +548,7 @@ export const createPremindPlugin = (dependencies: PremindPluginDependencies = {}
         async execute(_args, ctx) {
           const sessionId = ctx.sessionID ?? lastPrimarySessionId
           if (!sessionId) return "premind pause failed: no active session"
-          await daemon.pauseSession(sessionId)
+          await withReattach(sessionId, () => daemon.pauseSession(sessionId))
           return `premind paused for session ${sessionId}`
         },
       }),
@@ -511,7 +558,7 @@ export const createPremindPlugin = (dependencies: PremindPluginDependencies = {}
         async execute(_args, ctx) {
           const sessionId = ctx.sessionID ?? lastPrimarySessionId
           if (!sessionId) return "premind resume failed: no active session"
-          await daemon.resumeSession(sessionId)
+          await withReattach(sessionId, () => daemon.resumeSession(sessionId))
           return `premind resumed for session ${sessionId}`
         },
       }),
@@ -581,9 +628,9 @@ export const createPremindPlugin = (dependencies: PremindPluginDependencies = {}
       if (event.type === "session.status") {
         const statusType = (event.properties as Record<string, any>)?.status?.type
         if (statusType === "busy" || statusType === "retry") {
-          await daemon.updateSessionState({ sessionId: sessionID, busyState: "busy" }).catch((error) => {
-            if (!isSessionNotFound(error)) throw error
-          })
+          await withReattach(sessionID, () =>
+            daemon.updateSessionState({ sessionId: sessionID, busyState: "busy" }),
+          )
           cancelDelivery(sessionID)
         }
         if (statusType === "idle") {
@@ -639,9 +686,11 @@ export const createPremindPlugin = (dependencies: PremindPluginDependencies = {}
         return
       }
 
-      await daemon.updateSessionState({ sessionId: input.sessionID, busyState: "busy" }).catch((error) => {
-        if (!isSessionNotFound(error)) throw error
-      })
+      // Mark the session busy. If the session isn't registered yet (e.g. opencode
+      // resumed a past session, or the daemon DB was wiped), re-attach and retry.
+      await withReattach(input.sessionID, () =>
+        daemon.updateSessionState({ sessionId: input.sessionID, busyState: "busy" }),
+      )
       cancelDelivery(input.sessionID)
     },
   }


### PR DESCRIPTION
## Summary

Fixes the silent-zombie-session problem where opencode-resumed sessions (or sessions that predated a daemon DB wipe) never re-registered with premind, so they disappeared from `/premind-status` and never received PR reminders — all while the plugin happily swallowed `SESSION_NOT_FOUND` errors into the void.

## What changed

Three commits, each independently meaningful:

1. **`e2b5cac` — Skip replay of historical PR events on session re-attach.** Store-side: `registerSession` now returns `{ created }`, and `recordBranchAssociation` fast-forwards `last_delivered_event_seq` to the current `MAX(seq)` for any session whose `pr_number` is newly set. Idempotent re-associations leave the cursor alone. This prevents reattached sessions from being dumped with historical events the user already acted on when registration state was lost. +4 unit tests.

2. **`72f990d` — Re-attach sessions to the daemon on first event after resume.** Plugin-side: new `withReattach(sessionID, fn)` helper wraps daemon calls; on `SESSION_NOT_FOUND` it calls `attachSession("reattach")` and retries once. Wired into `handleSessionIdle`, the `session.status` busy branch, the `chat.message` busy update, and the pause/resume slash commands + tools. `attachSession` now returns `Promise<boolean>` so re-attach can distinguish a real registration from a deliberate bail-out on child sessions (parentID set). +6 integration tests in a new `reattach.test.ts` harness.

3. **`e5ecb26` — Log session register/re-register outcomes in the daemon IPC router.** Observability: router now logs `session registered` vs `session re-registered` with `{ sessionId, repo, branch, reattach }` so the daemon log shows when the reactive path fires.

## Triggers that now auto-re-attach

| Event | Handler | Call that hits SESSION_NOT_FOUND | Behavior |
|---|---|---|---|
| `session.idle` | `handleSessionIdle` | `updateSessionState` | attach + retry |
| `session.status` (busy/retry) | event handler | `updateSessionState` | attach + retry |
| `chat.message` (non-reminder) | handler tail | `updateSessionState` | attach + retry |
| `/premind-pause`, `/premind-resume` | command handlers | `pauseSession` / `resumeSession` | attach + retry |
| `premind_pause`, `premind_resume` tools | tool executes | same | attach + retry |

Child sessions (parentID set) are deliberately **not** re-attached — premind only tracks primary sessions, which matches existing behavior on initial `session.created`.

## Testing

- **Store**: 4 new unit tests covering `{created}` return, fresh-PR skip-replay, idempotent re-association (cursor preserved).
- **Plugin**: 6 new integration tests in `reattach.test.ts` covering chat.message / session.idle / session.status / known session no-op / child session bail-out / `/premind-pause` tool path.
- **Full suite**: 108/108 pass (was 102 on main). Typecheck clean.

## Not done (deferred)

- **Proactive enumerate-at-init (A2)** — considered and rejected for now; reactive reconcile handles the common case without risking revival of stale sessions. Can be added behind a flag later if the "resume and walk away" case bites in practice.
- **Immediate toast on re-attach** — per design decision, attach stays silent; details already surface via `plugin-runtime.json` and the new daemon log line.

## Verification

```
$ bun run check      # tsc --noEmit, exit 0
$ bun run test       # 108 pass, 0 fail, 18 suites
$ git log main..HEAD # 3 commits
```