### PR TITLE
Surface blockers when tracking starts

### DIFF
--- a/src/daemon/github/diff.test.ts
+++ b/src/daemon/github/diff.test.ts
@@ -26,6 +26,81 @@ const baseSnapshot = (): PullRequestSnapshot => ({
 })
 
 describe("diffSnapshot", () => {
+  test("emits a low-priority initialized event for a clean PR", () => {
+    const next: PullRequestSnapshot = {
+      ...baseSnapshot(),
+      core: { ...baseSnapshot().core, isDraft: false, mergeStateStatus: "CLEAN", reviewDecision: null },
+    }
+
+    const events = diffSnapshot(null, next)
+    assert.equal(events.length, 1)
+    const init = events[0]
+    assert.equal(init.kind, "pr.snapshot.initialized")
+    assert.equal(init.priority, "low")
+    assert.equal(init.summary, "Started tracking 42: Improve reminders")
+    assert.equal(init.payload.mergeStateStatus, "CLEAN")
+    assert.deepEqual(init.payload.failingChecks, [])
+  })
+
+  test("surfaces existing merge conflicts on the initialized event", () => {
+    const next: PullRequestSnapshot = {
+      ...baseSnapshot(),
+      core: { ...baseSnapshot().core, isDraft: false, mergeStateStatus: "DIRTY" },
+    }
+
+    const events = diffSnapshot(null, next)
+    const init = events.find((event) => event.kind === "pr.snapshot.initialized")
+    assert.ok(init)
+    assert.equal(init.priority, "high")
+    assert.match(init.summary, /merge conflict/i)
+    assert.equal(init.payload.mergeStateStatus, "DIRTY")
+  })
+
+  test("surfaces existing failing checks on the initialized event", () => {
+    const next: PullRequestSnapshot = {
+      ...baseSnapshot(),
+      core: { ...baseSnapshot().core, isDraft: false },
+      checks: [
+        { name: "build", state: "fail", link: "https://ci.example/build" },
+        { name: "lint", state: "success" },
+      ],
+    }
+
+    const events = diffSnapshot(null, next)
+    const init = events.find((event) => event.kind === "pr.snapshot.initialized")
+    assert.ok(init)
+    assert.equal(init.priority, "high")
+    assert.match(init.summary, /build/)
+    assert.deepEqual(init.payload.failingChecks, ["build"])
+  })
+
+  test("surfaces an existing changes-requested decision on the initialized event", () => {
+    const next: PullRequestSnapshot = {
+      ...baseSnapshot(),
+      core: { ...baseSnapshot().core, isDraft: false, reviewDecision: "CHANGES_REQUESTED" },
+    }
+
+    const events = diffSnapshot(null, next)
+    const init = events.find((event) => event.kind === "pr.snapshot.initialized")
+    assert.ok(init)
+    assert.equal(init.priority, "high")
+    assert.match(init.summary, /changes requested/i)
+    assert.equal(init.payload.reviewDecision, "CHANGES_REQUESTED")
+  })
+
+  test("does not flag UNKNOWN merge state as a conflict on initialization", () => {
+    const next: PullRequestSnapshot = {
+      ...baseSnapshot(),
+      core: { ...baseSnapshot().core, isDraft: false, mergeStateStatus: "UNKNOWN" },
+    }
+
+    const events = diffSnapshot(null, next)
+    const init = events.find((event) => event.kind === "pr.snapshot.initialized")
+    assert.ok(init)
+    assert.equal(init.priority, "low")
+    assert.doesNotMatch(init.summary, /merge conflict/i)
+  })
+
   test("detects high-signal PR events", () => {
     const previous = baseSnapshot()
     const next: PullRequestSnapshot = {

--- a/src/daemon/github/diff.ts
+++ b/src/daemon/github/diff.ts
@@ -60,17 +60,48 @@ const sampleSummaries = (bucket: NormalizedPrEvent[], max = 2) => bucket.slice(0
 
 export function diffSnapshot(previous: PullRequestSnapshot | null, next: PullRequestSnapshot): NormalizedPrEvent[] {
   if (!previous) {
+    // On the very first snapshot we have no prior state to diff against, so the
+    // transition-based detectors below never fire. A PR can already be in a bad
+    // state when tracking begins (e.g. the head commit was pushed before the PR
+    // was opened), so surface any pre-existing blockers directly on the
+    // initialization event. This lets the agent know it can start fixing merge
+    // conflicts / failing checks / requested changes right away instead of
+    // waiting for a later transition that may never come.
+    const failingChecks = next.checks
+      .filter((check) => checkKind(check.state) === "check.failed")
+      .map((check) => check.name || "unnamed check")
+
+    const mergeState = (next.core.mergeStateStatus ?? "").toUpperCase()
+    const hasMergeConflict = mergeState === "DIRTY"
+    const changesRequested = next.core.reviewDecision === "CHANGES_REQUESTED"
+
+    const blockers: string[] = []
+    if (hasMergeConflict) blockers.push("merge conflicts present")
+    if (failingChecks.length > 0) {
+      blockers.push(
+        `${failingChecks.length} check${failingChecks.length === 1 ? "" : "s"} failing (${failingChecks.join(", ")})`,
+      )
+    }
+    if (changesRequested) blockers.push("changes requested")
+
+    const baseSummary = `Started tracking ${next.core.number}: ${next.core.title}`
+    const summary = blockers.length > 0 ? `${baseSummary} — ${blockers.join("; ")}` : baseSummary
+
     return [
       {
         dedupeKey: `pr.snapshot.initial:${next.core.number}:${next.core.headRefOid}`,
         kind: "pr.snapshot.initialized",
-        priority: "low",
-        summary: `Started tracking ${next.core.number}: ${next.core.title}`,
+        priority: blockers.length > 0 ? "high" : "low",
+        summary,
         referenceLink: next.core.url,
         payload: {
           prNumber: next.core.number,
           headSha: next.core.headRefOid,
           reviewDecision: next.core.reviewDecision ?? null,
+          mergeStateStatus: next.core.mergeStateStatus ?? null,
+          hasMergeConflict,
+          failingChecks,
+          changesRequested,
         },
       },
     ]

--- a/src/daemon/persistence/store.test.ts
+++ b/src/daemon/persistence/store.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict"
 import fs from "node:fs"
 import os from "node:os"
 import path from "node:path"
+import { DatabaseSync } from "node:sqlite"
 import { afterEach, describe, test } from "node:test"
 import { StateStore } from "./store.ts"
 import type { PullRequestSnapshot } from "../github/types.ts"
@@ -1160,16 +1161,17 @@ describe("StateStore", () => {
     store.close()
   })
 
-  test("migrates pr_events.detail_file_path -> reference_link on existing databases", async () => {
+  test("migrates pr_events.detail_file_path -> reference_link on existing databases", () => {
     // Build a database that mimics the pre-rename schema, then open it with
-    // StateStore and verify the column got renamed in-place.
-    const Database = (await import("better-sqlite3")).default
+    // StateStore and verify the column got renamed in-place. We use the same
+    // built-in node:sqlite driver StateStore uses, so the test needs no extra
+    // (and intentionally absent) better-sqlite3 dependency.
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "premind-store-test-"))
     const dbPath = path.join(dir, "premind.db")
     tempPaths.push(dir)
 
     // Hand-craft the legacy schema with the old column name.
-    const legacy = new Database(dbPath)
+    const legacy = new DatabaseSync(dbPath)
     legacy.exec(`
       CREATE TABLE pr_events (
         seq INTEGER PRIMARY KEY AUTOINCREMENT,


### PR DESCRIPTION
## Summary
- When premind first starts tracking a PR, the `pr.snapshot.initialized` event now surfaces any pre-existing blockers so the agent can act immediately instead of waiting for a later state transition that may never come.
- Detects and reports existing merge conflicts (`mergeStateStatus` DIRTY, ignoring transient UNKNOWN), failing checks (by name), and a CHANGES_REQUESTED review decision.
- Raises the initialized event to `high` priority when any blocker exists and includes an actionable summary (e.g. "Started tracking 42: … — merge conflicts present; 2 checks failing (build, lint); changes requested"); clean PRs keep the original low-priority summary.
- Adds blocker details (`mergeStateStatus`, `hasMergeConflict`, `failingChecks`, `changesRequested`) to the event payload; `kind` and `dedupeKey` are unchanged to preserve delivery-cursor behavior.
- Fixes a pre-existing CI typecheck failure: the store migration test imported `better-sqlite3` (intentionally not a dependency, enforced by `packaging.test.ts`), which broke `tsc` on a clean install. The test now uses `DatabaseSync` from Node's built-in `node:sqlite` — the same driver `StateStore` uses — resolving both the typecheck error and a runtime native-module version mismatch.

## Testing
- Added unit tests in `diff.test.ts` covering clean, merge-conflict, failing-check, changes-requested, and UNKNOWN-merge-state initialization cases.
- `diff.test.ts` — 11/11 pass; `store.test.ts` — 39/39 pass; watcher integration — 7/7 pass; `packaging.test.ts` — 5/5 pass.
- `tsc -p tsconfig.json --noEmit` — clean.
- CI on the PR: Typecheck, Unit tests, and Compatibility tests all green.

## Risks
- Low: the blockers change is scoped to the first-snapshot branch of `diffSnapshot`; event `kind`/`dedupeKey` unchanged, so cursor and dedup behavior are preserved.
- Initialized events with blockers are now `high` priority, so they bypass reminder condensing and reach the agent on first prompt — intended, but slightly more prominent than before.
- The test-only switch to `node:sqlite` keeps parity with the production driver and adds no new dependency.

_(Drafted by Jacob's coding agent on his behalf)_
