### PR TITLE
Prevent stale Pi extension contexts from crashing polling

### DIFF
--- a/src/extension/__tests__/index.test.ts
+++ b/src/extension/__tests__/index.test.ts
@@ -423,7 +423,7 @@ describe("premind Pi extension", () => {
 	});
 
 	test(
-		"in-flight status polling ignores a context after session shutdown",
+		"in-flight status polling tolerates a context invalidated before shutdown",
 		async (t) => {
 			t.mock.timers.enable({ apis: ["setInterval"] });
 			const mock = createMockPi();
@@ -446,10 +446,13 @@ describe("premind Pi extension", () => {
 			};
 
 			let contextIsStale = false;
-			let staleContextReads = 0;
 			Object.defineProperty(ctx, "hasUI", {
 				get() {
-					if (contextIsStale) staleContextReads++;
+					if (contextIsStale) {
+						throw new Error(
+							"This extension ctx is stale after session replacement or reload.",
+						);
+					}
 					return true;
 				},
 			});
@@ -466,18 +469,49 @@ describe("premind Pi extension", () => {
 			await start({}, ctx);
 			t.mock.timers.tick(5_000);
 			await pollStarted;
-			await shutdown({}, ctx);
+			const statusCountBeforeInvalidation = statuses.length;
 			contextIsStale = true;
 			resolvePoll(status);
 			await new Promise<void>((resolve) => setImmediate(resolve));
 
-			assert.equal(staleContextReads, 0);
-			assert.deepEqual(statuses.at(-1), {
-				key: "premind",
-				value: undefined,
-			});
+			assert.equal(statuses.length, statusCountBeforeInvalidation);
+			await shutdown({}, ctx);
 		},
 	);
+
+	test("status polling treats a stale extension API as cancellation", async (t) => {
+		t.mock.timers.enable({ apis: ["setInterval"] });
+		const mock = createMockPi();
+		const client = createClient({ pendingBatch: reminderBatch });
+		const { ctx, statuses } = createEventContext();
+		mock.pi.sendMessage = () => {
+			throw new Error(
+				"This extension ctx is stale after session replacement or reload.",
+			);
+		};
+		createPremindPiExtension({
+			createDaemonClient: () => client.client,
+			config: { statusPollIntervalMs: 5_000 },
+			detectGit: async () => ({ repo: "owner/repo", branch: "feature/pi" }),
+		})(mock.pi as never);
+
+		const start = mock.events.get("session_start");
+		const shutdown = mock.events.get("session_shutdown");
+		assert.ok(start);
+		assert.ok(shutdown);
+		await start({}, ctx);
+		statuses.length = 0;
+		t.mock.timers.tick(5_000);
+		await new Promise<void>((resolve) => setImmediate(resolve));
+
+		assert.deepEqual(statuses, [{ key: "premind", value: undefined }]);
+		assert.ok(
+			client.operations.includes(
+				"ackReminder:batch-1:/tmp/session.jsonl:failed",
+			),
+		);
+		await shutdown({}, ctx);
+	});
 
 	test("agent lifecycle updates busy state and auto-delivers pending reminders on idle", async () => {
 		const mock = createMockPi();

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -79,6 +79,11 @@ const DEFAULT_STATUS_POLL_INTERVAL_MS = 15_000;
 const MIN_STATUS_POLL_INTERVAL_MS = 5_000;
 const REMINDER_VISIBLE_EVENT_LIMIT = 3;
 const PR_ICON = ""; // nf-oct-git_pull_request
+const STALE_EXTENSION_CONTEXT_PREFIX = "This extension ctx is stale";
+
+const isStaleExtensionContextError = (error: unknown): boolean =>
+	error instanceof Error &&
+	error.message.startsWith(STALE_EXTENSION_CONTEXT_PREFIX);
 
 const priorityRank: Record<
 	ReminderBatch["events"][number]["priority"],
@@ -283,8 +288,36 @@ export const createPremindPiExtension = (
 			},
 			value?: string,
 		) => {
-			if (!ctx.hasUI) return;
-			ctx.ui?.setStatus?.("premind", config.showStatusbar ? value : undefined);
+			try {
+				if (!ctx.hasUI) return;
+				ctx.ui?.setStatus?.(
+					"premind",
+					config.showStatusbar ? value : undefined,
+				);
+			} catch (error) {
+				if (!isStaleExtensionContextError(error)) throw error;
+			}
+		};
+
+		const notify = (
+			ctx: {
+				hasUI?: boolean;
+				ui?: {
+					notify?: (
+						message: string,
+						level: "info" | "warning" | "error",
+					) => void;
+				};
+			},
+			message: string,
+			level: "info" | "warning" | "error",
+		) => {
+			try {
+				if (ctx.hasUI === false) return;
+				ctx.ui?.notify?.(message, level);
+			} catch (error) {
+				if (!isStaleExtensionContextError(error)) throw error;
+			}
 		};
 
 		const refreshStatusbar = async (
@@ -417,8 +450,11 @@ export const createPremindPiExtension = (
 					if (generation !== sessionGeneration) return;
 					if (result.delivered) setStatus(ctx, undefined);
 				}
-			} catch {
-				if (generation === sessionGeneration)
+			} catch (error) {
+				if (
+					generation === sessionGeneration &&
+					!isStaleExtensionContextError(error)
+				)
 					setStatus(ctx, `${PR_ICON} error`);
 			} finally {
 				statusPollInFlight = false;
@@ -485,12 +521,11 @@ export const createPremindPiExtension = (
 			} catch (error) {
 				if (generation !== sessionGeneration) return;
 				setStatus(ctx, `${PR_ICON} error`);
-				if (ctx.hasUI) {
-					ctx.ui.notify(
-						`premind session registration failed: ${error instanceof Error ? error.message : String(error)}`,
-						"error",
-					);
-				}
+				notify(
+					ctx,
+					`premind session registration failed: ${error instanceof Error ? error.message : String(error)}`,
+					"error",
+				);
 			}
 		});
 
@@ -512,12 +547,11 @@ export const createPremindPiExtension = (
 				}
 			} catch (error) {
 				setStatus(ctx, `${PR_ICON} error`);
-				if (ctx.hasUI) {
-					ctx.ui.notify(
-						`premind automatic delivery failed: ${error instanceof Error ? error.message : String(error)}`,
-						"error",
-					);
-				}
+				notify(
+					ctx,
+					`premind automatic delivery failed: ${error instanceof Error ? error.message : String(error)}`,
+					"error",
+				);
 			}
 		});
 


### PR DESCRIPTION
## Summary
- audit Premind's timers and asynchronous callbacks for retained Pi session contexts
- make status and notification UI updates ignore Pi's explicit stale-context cancellation error while preserving unexpected failures
- prevent the status poll's error fallback from reusing an already-stale context
- treat stale `pi.sendMessage` access during reminder delivery as poll cancellation rather than another UI error
- reproduce runner invalidation directly in regression tests instead of relying only on `session_shutdown` generation changes

## Testing
- `node --import tsx --test src/extension/__tests__/index.test.ts` (17 passed)
- `npm run check`
- `npm test` (189 passed)

_(Drafted by Jacob's coding agent on his behalf)_