### PR TITLE
Fix missed PR blocker reminders

### DIFF
--- a/src/daemon/github/diff.test.ts
+++ b/src/daemon/github/diff.test.ts
@@ -328,54 +328,36 @@ describe("diffSnapshot", () => {
     assert.equal(decisionEvent.payload.reviewDecision, "CHANGES_REQUESTED")
   })
 
-  test("debounces merge conflict events when state is UNKNOWN", () => {
+  test("suppresses UNKNOWN merge states while retaining the last stable baseline", () => {
+    const clean = { ...baseSnapshot().core, isDraft: false, mergeStateStatus: "CLEAN" }
+    const unknown = { ...clean, mergeStateStatus: "UNKNOWN", lastStableMergeStateStatus: "CLEAN" }
+
     // Transition from CLEAN to UNKNOWN should not emit.
-    const previous1: PullRequestSnapshot = {
-      ...baseSnapshot(),
-      core: { ...baseSnapshot().core, isDraft: false, mergeStateStatus: "CLEAN" },
-    }
-    const next1: PullRequestSnapshot = {
-      ...previous1,
-      core: { ...previous1.core, mergeStateStatus: "UNKNOWN" },
-    }
-    const events1 = diffSnapshot(previous1, next1)
-    assert.ok(!events1.some((e) => e.kind === "merge_conflict.detected"))
-    assert.ok(!events1.some((e) => e.kind === "merge_conflict.cleared"))
+    const events1 = diffSnapshot(
+      { ...baseSnapshot(), core: clean },
+      { ...baseSnapshot(), core: unknown },
+    )
+    assert.ok(!events1.some((event) => event.kind === "merge_conflict.detected"))
+    assert.ok(!events1.some((event) => event.kind === "merge_conflict.cleared"))
 
-    // Transition from UNKNOWN to DIRTY should not emit.
-    const previous2: PullRequestSnapshot = {
-      ...baseSnapshot(),
-      core: { ...baseSnapshot().core, isDraft: false, mergeStateStatus: "UNKNOWN" },
-    }
-    const next2: PullRequestSnapshot = {
-      ...previous2,
-      core: { ...previous2.core, mergeStateStatus: "DIRTY" },
-    }
-    const events2 = diffSnapshot(previous2, next2)
-    assert.ok(!events2.some((e) => e.kind === "merge_conflict.detected"))
+    // A stable outcome after UNKNOWN compares against the retained CLEAN baseline.
+    const events2 = diffSnapshot(
+      { ...baseSnapshot(), core: unknown },
+      { ...baseSnapshot(), core: { ...unknown, mergeStateStatus: "DIRTY" } },
+    )
+    assert.ok(events2.some((event) => event.kind === "merge_conflict.detected"))
 
-    // Transition from CLEAN to DIRTY should emit.
-    const previous3: PullRequestSnapshot = {
-      ...baseSnapshot(),
-      core: { ...baseSnapshot().core, isDraft: false, mergeStateStatus: "CLEAN" },
-    }
-    const next3: PullRequestSnapshot = {
-      ...previous3,
-      core: { ...previous3.core, mergeStateStatus: "DIRTY" },
-    }
-    const events3 = diffSnapshot(previous3, next3)
-    assert.ok(events3.some((e) => e.kind === "merge_conflict.detected"))
+    // A stable direct transition still emits as before.
+    const events3 = diffSnapshot(
+      { ...baseSnapshot(), core: clean },
+      { ...baseSnapshot(), core: { ...clean, mergeStateStatus: "DIRTY" } },
+    )
+    assert.ok(events3.some((event) => event.kind === "merge_conflict.detected"))
 
-    // Transition from DIRTY to CLEAN should emit.
-    const previous4: PullRequestSnapshot = {
-      ...baseSnapshot(),
-      core: { ...baseSnapshot().core, isDraft: false, mergeStateStatus: "DIRTY" },
-    }
-    const next4: PullRequestSnapshot = {
-      ...previous4,
-      core: { ...previous4.core, mergeStateStatus: "CLEAN" },
-    }
-    const events4 = diffSnapshot(previous4, next4)
-    assert.ok(events4.some((e) => e.kind === "merge_conflict.cleared"))
+    const events4 = diffSnapshot(
+      { ...baseSnapshot(), core: { ...clean, mergeStateStatus: "DIRTY" } },
+      { ...baseSnapshot(), core: clean },
+    )
+    assert.ok(events4.some((event) => event.kind === "merge_conflict.cleared"))
   })
 })

--- a/src/daemon/github/diff.ts
+++ b/src/daemon/github/diff.ts
@@ -1,5 +1,9 @@
 import type { NormalizedPrEvent, PullRequestCheck, PullRequestSnapshot } from "./types.ts"
 
+export const stableMergeStateStatus = (state?: string) => {
+  const normalized = (state ?? "").toUpperCase()
+  return normalized && normalized !== "UNKNOWN" ? normalized : undefined
+}
 const compact = (value: string | null | undefined, max = 160) => {
   const text = (value ?? "").replace(/\s+/g, " ").trim()
   if (!text) return ""
@@ -142,15 +146,15 @@ export function diffSnapshot(previous: PullRequestSnapshot | null, next: PullReq
     })
   }
 
-  if (previous.core.mergeStateStatus !== next.core.mergeStateStatus) {
-    const previousState = (previous.core.mergeStateStatus ?? "").toUpperCase()
-    const nextState = (next.core.mergeStateStatus ?? "").toUpperCase()
-
-    // Debounce: do not emit merge events when either side is UNKNOWN or empty.
-    // GitHub transiently reports UNKNOWN while computing mergeability.
-    const isStable = previousState !== "UNKNOWN" && previousState !== "" && nextState !== "UNKNOWN" && nextState !== ""
-
-    if (isStable && nextState === "DIRTY") {
+  const previousStableMergeState =
+    previous.core.lastStableMergeStateStatus ?? stableMergeStateStatus(previous.core.mergeStateStatus)
+  const nextStableMergeState = stableMergeStateStatus(next.core.mergeStateStatus)
+  if (
+    previousStableMergeState !== undefined &&
+    nextStableMergeState !== undefined &&
+    previousStableMergeState !== nextStableMergeState
+  ) {
+    if (nextStableMergeState === "DIRTY") {
       events.push({
         dedupeKey: `merge_conflict.detected:${next.core.number}:${next.core.headRefOid}`,
         kind: "merge_conflict.detected",
@@ -160,7 +164,7 @@ export function diffSnapshot(previous: PullRequestSnapshot | null, next: PullReq
         payload: { mergeStateStatus: next.core.mergeStateStatus ?? null },
       })
     }
-    if (isStable && nextState === "CLEAN") {
+    if (nextStableMergeState === "CLEAN") {
       events.push({
         dedupeKey: `merge_conflict.cleared:${next.core.number}:${next.core.headRefOid}`,
         kind: "merge_conflict.cleared",

--- a/src/daemon/github/types.ts
+++ b/src/daemon/github/types.ts
@@ -8,6 +8,8 @@ export type PullRequestCore = {
   baseRefName: string
   headRefOid: string
   mergeStateStatus?: string
+  /** Most recent non-transient merge state, retained across GitHub UNKNOWN responses. */
+  lastStableMergeStateStatus?: string
   reviewDecision?: string | null
   updatedAt?: string
   reviewRequests?: Array<{ login: string }>

--- a/src/daemon/persistence/store.test.ts
+++ b/src/daemon/persistence/store.test.ts
@@ -80,6 +80,10 @@ describe("StateStore", () => {
     const batch = store.buildReminderBatch("session-1")
     assert.ok(batch)
     assert.equal(batch.events.length, 2)
+    assert.match(
+      batch.reminderText,
+      /Action required: investigate and address the failing checks or merge conflicts above/,
+    )
 
     const pending = store.getPendingReminder("session-1")
     assert.equal(pending?.batchId, batch.batchId)
@@ -122,6 +126,7 @@ describe("StateStore", () => {
 
     const batch = store.buildReminderBatch("session-2")
     assert.ok(batch)
+    assert.doesNotMatch(batch.reminderText, /Action required:/)
 
     store.ackReminder({
       batchId: batch!.batchId,

--- a/src/daemon/persistence/store.ts
+++ b/src/daemon/persistence/store.ts
@@ -916,21 +916,30 @@ export class StateStore {
 			if (priorityDelta !== 0) return priorityDelta;
 			return Number(left.eventId) - Number(right.eventId);
 		});
-
+		const hasActionableBlocker = condensed.some((event) =>
+			["check.failed", "merge_conflict.detected"].includes(event.kind),
+		);
 		const reminderText = [
 			"<system-reminder>",
 			"New pull request context was detected since the last reminder.",
 			"",
 			"Changes:",
 			...condensed.map(
+
 				(event, index) =>
 					`${index + 1}. ${event.kind} - ${event.summary}${event.referenceLink ? ` (${event.referenceLink})` : ""}`,
 			),
+			...(hasActionableBlocker
+
+				? [
+						"",
+						"Action required: investigate and address the failing checks or merge conflicts above before continuing the current task. If you cannot resolve them, explain why.",
+					]
+				: []),
 			"",
 			"Please incorporate only the new information above into your reasoning and continue the current task.",
 			"</system-reminder>",
 		].join("\n");
-
 		const batchId = this.createOrReplaceReminder(
 			sessionId,
 			reminderText,

--- a/src/daemon/watchers/integration.test.ts
+++ b/src/daemon/watchers/integration.test.ts
@@ -189,6 +189,42 @@ describe("watcher integration", () => {
     store.close()
   })
 
+  test("PR watcher detects conflicts after GitHub transiently reports UNKNOWN", async () => {
+    const store = createStore()
+    const github = new FixtureGitHubClient()
+    const prWatcher = new PullRequestWatcher(store, github)
+
+    store.registerClient("client-conflict", { pid: 3, projectRoot: "/tmp" })
+    store.registerSession({
+      clientId: "client-conflict",
+      sessionId: "session-conflict",
+      repo: "acme/repo",
+      branch: "feature/conflict",
+      isPrimary: true,
+      status: "active",
+      busyState: "idle",
+    })
+    store.recordBranchAssociation("acme/repo", "feature/conflict", 42)
+
+    const snapshotWithMergeState = (mergeStateStatus: string) => {
+      const snapshot = makeSnapshot()
+      return { ...snapshot, core: { ...snapshot.core, mergeStateStatus } }
+    }
+    github.pushSnapshot(snapshotWithMergeState("CLEAN"))
+    github.pushSnapshot(snapshotWithMergeState("UNKNOWN"))
+    github.pushSnapshot(snapshotWithMergeState("DIRTY"))
+
+    await prWatcher.tick()
+    await prWatcher.tick()
+    await prWatcher.tick()
+
+    const events = store.listUndeliveredEvents("session-conflict")
+    assert.ok(events.some((event) => event.kind === "merge_conflict.detected"))
+    assert.equal(store.getSnapshot("acme/repo", 42)?.core.lastStableMergeStateStatus, "DIRTY")
+
+    store.close()
+  })
+
   test("two sessions on same PR get independent delivery cursors", async () => {
     const store = createStore()
     const github = new FixtureGitHubClient()

--- a/src/daemon/watchers/pr-watcher.ts
+++ b/src/daemon/watchers/pr-watcher.ts
@@ -1,4 +1,4 @@
-import { diffSnapshot } from "../github/diff.ts"
+import { diffSnapshot, stableMergeStateStatus } from "../github/diff.ts"
 import type { GitHubClientLike } from "../github/client.ts"
 import { createLogger } from "../logging/logger.ts"
 import { StateStore } from "../persistence/store.ts"
@@ -58,7 +58,17 @@ export class PullRequestWatcher {
           continue
         }
 
-        const next = result.snapshot
+        const stableMergeState = stableMergeStateStatus(result.snapshot.core.mergeStateStatus)
+        const next = {
+          ...result.snapshot,
+          core: {
+            ...result.snapshot.core,
+            lastStableMergeStateStatus:
+              stableMergeState ??
+              previous?.core.lastStableMergeStateStatus ??
+              stableMergeStateStatus(previous?.core.mergeStateStatus),
+          },
+        }
         const events = diffSnapshot(previous, next)
 
         this.store.saveSnapshot(target.repo, target.pr_number, next)


### PR DESCRIPTION
## Summary
- retain the last stable merge state across GitHub `UNKNOWN` responses so eventual conflicts are reported
- explicitly direct the model to investigate failed checks and merge conflicts
- add unit and watcher integration coverage

## Validation
- `npm run check`
- `node --import tsx --test src/daemon/github/diff.test.ts src/daemon/watchers/integration.test.ts src/daemon/persistence/store.test.ts`

_(Drafted by Jacob's coding agent on his behalf)