### PR TITLE
Add merged PR reminders

### DIFF
--- a/src/daemon/github/diff.test.ts
+++ b/src/daemon/github/diff.test.ts
@@ -360,4 +360,46 @@ describe("diffSnapshot", () => {
     )
     assert.ok(events4.some((event) => event.kind === "merge_conflict.cleared"))
   })
+  test("emits a merge reminder when a PR becomes merged", () => {
+    const previous = baseSnapshot()
+    const next = { ...previous, core: { ...previous.core, state: "MERGED" } }
+
+    const merged = diffSnapshot(previous, next).find((event) => event.kind === "pr.merged")
+
+    assert.ok(merged)
+    assert.equal(merged.priority, "high")
+    assert.equal(merged.dedupeKey, "pr.merged:https://github.com/acme/repo/pull/42")
+    assert.equal(merged.payload.previousState, "OPEN")
+    assert.equal(merged.payload.state, "MERGED")
+  })
+
+  test("surfaces an already-merged initial snapshot", () => {
+    const next = { ...baseSnapshot(), core: { ...baseSnapshot().core, state: "MERGED" } }
+
+    const merged = diffSnapshot(null, next).find((event) => event.kind === "pr.merged")
+
+    assert.ok(merged)
+    assert.equal(merged.payload.previousState, null)
+  })
+
+  test("does not report an unmerged closed PR as merged", () => {
+    const previous = baseSnapshot()
+    const next = { ...previous, core: { ...previous.core, state: "CLOSED" } }
+
+    assert.ok(!diffSnapshot(previous, next).some((event) => event.kind === "pr.merged"))
+  })
+
+  test("uses a repository-qualified merge dedupe key", () => {
+    const previous = baseSnapshot()
+    const first = { ...previous, core: { ...previous.core, state: "MERGED" } }
+    const second = { ...previous, core: { ...previous.core, url: "https://github.com/other/repo/pull/42", state: "MERGED" } }
+
+    const firstMerge = diffSnapshot(previous, first).find((event) => event.kind === "pr.merged")
+    const secondMerge = diffSnapshot(previous, second).find((event) => event.kind === "pr.merged")
+
+    assert.ok(firstMerge)
+    assert.ok(secondMerge)
+    assert.notEqual(firstMerge.dedupeKey, secondMerge.dedupeKey)
+  })
+
 })

--- a/src/daemon/github/diff.ts
+++ b/src/daemon/github/diff.ts
@@ -92,6 +92,27 @@ export function diffSnapshot(previous: PullRequestSnapshot | null, next: PullReq
     const summary = blockers.length > 0 ? `${baseSummary} — ${blockers.join("; ")}` : baseSummary
 
     return [
+      ...(next.core.state === "MERGED"
+        ? [
+            {
+              dedupeKey: `pr.merged:${next.core.url}`,
+              kind: "pr.merged",
+              priority: "high" as const,
+              summary: `Branch ${next.core.headRefName} was merged via PR #${next.core.number}: ${next.core.title}`,
+              referenceLink: next.core.url,
+              payload: {
+                prNumber: next.core.number,
+                title: next.core.title,
+                url: next.core.url,
+                branch: next.core.headRefName,
+                baseBranch: next.core.baseRefName,
+                headSha: next.core.headRefOid,
+                previousState: null,
+                state: next.core.state,
+              },
+            },
+          ]
+        : []),
       {
         dedupeKey: `pr.snapshot.initial:${next.core.number}:${next.core.headRefOid}`,
         kind: "pr.snapshot.initialized",
@@ -112,6 +133,26 @@ export function diffSnapshot(previous: PullRequestSnapshot | null, next: PullReq
   }
 
   const events: NormalizedPrEvent[] = []
+
+  if (previous.core.state !== "MERGED" && next.core.state === "MERGED") {
+    events.push({
+      dedupeKey: `pr.merged:${next.core.url}`,
+      kind: "pr.merged",
+      priority: "high",
+      summary: `Branch ${next.core.headRefName} was merged via PR #${next.core.number}: ${next.core.title}`,
+      referenceLink: next.core.url,
+      payload: {
+        prNumber: next.core.number,
+        title: next.core.title,
+        url: next.core.url,
+        branch: next.core.headRefName,
+        baseBranch: next.core.baseRefName,
+        headSha: next.core.headRefOid,
+        previousState: previous.core.state,
+        state: next.core.state,
+      },
+    })
+  }
 
   if (previous.core.isDraft && !next.core.isDraft) {
     events.push({

--- a/src/daemon/github/diff.ts
+++ b/src/daemon/github/diff.ts
@@ -60,6 +60,24 @@ const groupKinds = new Set([
   "review_comment.deleted",
 ])
 
+
+const mergedEvent = (next: PullRequestSnapshot, previousState: string | null): NormalizedPrEvent => ({
+  dedupeKey: `pr.merged:${next.core.url}`,
+  kind: "pr.merged",
+  priority: "high",
+  summary: `Branch ${next.core.headRefName} was merged via PR #${next.core.number}: ${next.core.title}`,
+  referenceLink: next.core.url,
+  payload: {
+    prNumber: next.core.number,
+    title: next.core.title,
+    url: next.core.url,
+    branch: next.core.headRefName,
+    baseBranch: next.core.baseRefName,
+    headSha: next.core.headRefOid,
+    previousState,
+    state: next.core.state,
+  },
+})
 const sampleSummaries = (bucket: NormalizedPrEvent[], max = 2) => bucket.slice(0, max).map((event) => event.summary)
 
 export function diffSnapshot(previous: PullRequestSnapshot | null, next: PullRequestSnapshot): NormalizedPrEvent[] {
@@ -94,23 +112,7 @@ export function diffSnapshot(previous: PullRequestSnapshot | null, next: PullReq
     return [
       ...(next.core.state === "MERGED"
         ? [
-            {
-              dedupeKey: `pr.merged:${next.core.url}`,
-              kind: "pr.merged",
-              priority: "high" as const,
-              summary: `Branch ${next.core.headRefName} was merged via PR #${next.core.number}: ${next.core.title}`,
-              referenceLink: next.core.url,
-              payload: {
-                prNumber: next.core.number,
-                title: next.core.title,
-                url: next.core.url,
-                branch: next.core.headRefName,
-                baseBranch: next.core.baseRefName,
-                headSha: next.core.headRefOid,
-                previousState: null,
-                state: next.core.state,
-              },
-            },
+            mergedEvent(next, null),
           ]
         : []),
       {
@@ -135,23 +137,7 @@ export function diffSnapshot(previous: PullRequestSnapshot | null, next: PullReq
   const events: NormalizedPrEvent[] = []
 
   if (previous.core.state !== "MERGED" && next.core.state === "MERGED") {
-    events.push({
-      dedupeKey: `pr.merged:${next.core.url}`,
-      kind: "pr.merged",
-      priority: "high",
-      summary: `Branch ${next.core.headRefName} was merged via PR #${next.core.number}: ${next.core.title}`,
-      referenceLink: next.core.url,
-      payload: {
-        prNumber: next.core.number,
-        title: next.core.title,
-        url: next.core.url,
-        branch: next.core.headRefName,
-        baseBranch: next.core.baseRefName,
-        headSha: next.core.headRefOid,
-        previousState: previous.core.state,
-        state: next.core.state,
-      },
-    })
+    events.push(mergedEvent(next, previous.core.state))
   }
 
   if (previous.core.isDraft && !next.core.isDraft) {

--- a/src/daemon/persistence/store.test.ts
+++ b/src/daemon/persistence/store.test.ts
@@ -100,6 +100,61 @@ describe("StateStore", () => {
     store.close()
   })
 
+
+  test("persists a snapshot and its events atomically", () => {
+    const store = createStore()
+    const mergedSnapshot = { ...snapshot(), core: { ...snapshot().core, state: "MERGED" } }
+    const events = [
+      {
+        dedupeKey: "pr.merged:https://github.com/acme/repo/pull/7",
+        kind: "pr.merged",
+        priority: "high" as const,
+        summary: "Branch feature/x was merged",
+        referenceLink: mergedSnapshot.core.url,
+        payload: { prNumber: 7, state: "MERGED" },
+      },
+    ]
+
+    store.saveSnapshotAndEvents("acme/repo", 7, mergedSnapshot, events, 123)
+
+    assert.equal(store.getSnapshot("acme/repo", 7)?.core.state, "MERGED")
+    const eventCount = (store as any).db
+      .prepare("SELECT COUNT(*) AS count FROM pr_events WHERE repo = ? AND pr_number = ?")
+      .get("acme/repo", 7) as { count: number }
+    assert.equal(eventCount.count, 1)
+
+    store.close()
+  })
+
+  test("rolls back the snapshot when event persistence fails", () => {
+    const store = createStore()
+    const mergedSnapshot = { ...snapshot(), core: { ...snapshot().core, state: "MERGED" } }
+    const invalidEvents = [
+      {
+        dedupeKey: "pr.merged:https://github.com/acme/repo/pull/7",
+        kind: "pr.merged",
+        priority: "high" as const,
+        summary: "Branch feature/x was merged",
+        payload: { prNumber: 7, state: "MERGED" },
+      },
+      {
+        dedupeKey: "invalid-event",
+        kind: "pr.merged",
+        priority: "high" as const,
+        summary: "Invalid event payload",
+        payload: { invalid: BigInt(1) },
+      },
+    ]
+
+    assert.throws(() => store.saveSnapshotAndEvents("acme/repo", 7, mergedSnapshot, invalidEvents, 123))
+    assert.equal(store.getSnapshot("acme/repo", 7), null)
+    const eventCount = (store as any).db
+      .prepare("SELECT COUNT(*) AS count FROM pr_events WHERE repo = ? AND pr_number = ?")
+      .get("acme/repo", 7) as { count: number }
+    assert.equal(eventCount.count, 0)
+
+    store.close()
+  })
   test("keeps failed reminder batches retryable", () => {
     const store = createStore()
 

--- a/src/daemon/persistence/store.ts
+++ b/src/daemon/persistence/store.ts
@@ -779,44 +779,71 @@ export class StateStore {
 			});
 	}
 
+	saveSnapshotAndEvents(
+		repo: string,
+		prNumber: number,
+		snapshot: PullRequestSnapshot,
+		events: NormalizedPrEvent[],
+		now = Date.now(),
+	) {
+		this.db.exec("BEGIN");
+		try {
+			this.saveSnapshot(repo, prNumber, snapshot);
+			this.insertEventsInTransaction(repo, prNumber, events, now);
+			this.db.exec("COMMIT");
+		} catch (error) {
+			this.db.exec("ROLLBACK");
+			throw error;
+		}
+	}
+
 	insertEvents(
 		repo: string,
 		prNumber: number,
 		events: NormalizedPrEvent[],
 		now = Date.now(),
 	) {
-		const insert = this.db.prepare(
-			`
-        INSERT OR IGNORE INTO pr_events (repo, pr_number, dedupe_key, kind, priority, summary, reference_link, payload_json, created_at)
-        VALUES (:repo, :prNumber, :dedupeKey, :kind, :priority, :summary, :referenceLink, :payloadJson, :now)
-      `,
-		);
-
 		this.db.exec("BEGIN");
 		try {
-			for (const event of events) {
-				// Prefer the local detail file (rich body content for comments and
-				// reviews). When the writer skips the file (no rich content for this
-				// kind, e.g. check.*), fall back to the GitHub URL the event was
-				// built with so the reminder still carries an actionable link.
-				const localPath = this.detailFiles.write(repo, prNumber, event);
-				const referenceLink = localPath ?? event.referenceLink ?? null;
-				insert.run({
-					repo,
-					prNumber,
-					dedupeKey: event.dedupeKey,
-					kind: event.kind,
-					priority: event.priority,
-					summary: event.summary,
-					referenceLink,
-					payloadJson: JSON.stringify(event.payload),
-					now,
-				});
-			}
+			this.insertEventsInTransaction(repo, prNumber, events, now);
 			this.db.exec("COMMIT");
 		} catch (error) {
 			this.db.exec("ROLLBACK");
 			throw error;
+		}
+	}
+
+	private insertEventsInTransaction(
+		repo: string,
+		prNumber: number,
+		events: NormalizedPrEvent[],
+		now: number,
+	) {
+		const insert = this.db.prepare(
+			`
+				INSERT OR IGNORE INTO pr_events (repo, pr_number, dedupe_key, kind, priority, summary, reference_link, payload_json, created_at)
+				VALUES (:repo, :prNumber, :dedupeKey, :kind, :priority, :summary, :referenceLink, :payloadJson, :now)
+			`,
+		);
+
+		for (const event of events) {
+			// Prefer the local detail file (rich body content for comments and
+			// reviews). When the writer skips the file (no rich content for this
+			// kind, e.g. check.*), fall back to the GitHub URL the event was
+			// built with so the reminder still carries an actionable link.
+			const localPath = this.detailFiles.write(repo, prNumber, event);
+			const referenceLink = localPath ?? event.referenceLink ?? null;
+			insert.run({
+				repo,
+				prNumber,
+				dedupeKey: event.dedupeKey,
+				kind: event.kind,
+				priority: event.priority,
+				summary: event.summary,
+				referenceLink,
+				payloadJson: JSON.stringify(event.payload),
+				now,
+			});
 		}
 	}
 

--- a/src/daemon/persistence/store.ts
+++ b/src/daemon/persistence/store.ts
@@ -722,7 +722,11 @@ export class StateStore {
 			)
 			.get(repo, prNumber) as { snapshot_json: string } | undefined;
 		if (!row) return null;
-		return JSON.parse(row.snapshot_json) as PullRequestSnapshot;
+		try {
+			return JSON.parse(row.snapshot_json) as PullRequestSnapshot;
+		} catch {
+			return null;
+		}
 	}
 
 	/**
@@ -954,12 +958,16 @@ export class StateStore {
 			)
 			.get(sessionId) as ReminderRow | undefined;
 		if (!row || row.state === "confirmed") return null;
-		return {
-			batchId: row.batch_id,
-			sessionId: row.session_id,
-			reminderText: row.reminder_text,
-			events: JSON.parse(row.events_json) as ReminderEvent[],
-		};
+		try {
+			return {
+				batchId: row.batch_id,
+				sessionId: row.session_id,
+				reminderText: row.reminder_text,
+				events: JSON.parse(row.events_json) as ReminderEvent[],
+			};
+		} catch {
+			return null;
+		}
 	}
 
 	ackReminder(payload: AckReminderPayload, now = Date.now()) {

--- a/src/daemon/watchers/branch-discovery.ts
+++ b/src/daemon/watchers/branch-discovery.ts
@@ -37,8 +37,9 @@ export class BranchDiscoveryWatcher {
         }
 
         const pr = result.pr
-        this.store.recordBranchAssociation(target.repo, target.branch, pr?.number ?? null, now)
-
+        if (pr || target.pr_number === null) {
+          this.store.recordBranchAssociation(target.repo, target.branch, pr?.number ?? null, now)
+        }
         if (!pr) continue
         if (target.pr_number === pr.number) continue
 

--- a/src/daemon/watchers/branch-discovery.ts
+++ b/src/daemon/watchers/branch-discovery.ts
@@ -37,9 +37,21 @@ export class BranchDiscoveryWatcher {
         }
 
         const pr = result.pr
-        if (pr || target.pr_number === null) {
-          this.store.recordBranchAssociation(target.repo, target.branch, pr?.number ?? null, now)
+        if (pr && target.pr_number !== null && pr.number !== target.pr_number) {
+          const previousSnapshot = this.store.getSnapshot(target.repo, target.pr_number)
+          const previousState = previousSnapshot?.core.state
+          if (previousState !== "MERGED" && previousState !== "CLOSED") {
+            this.logger.info("deferring branch reassociation until prior PR reaches a terminal state", {
+              repo: target.repo,
+              branch: target.branch,
+              previousPrNumber: target.pr_number,
+              nextPrNumber: pr.number,
+              previousState: previousState ?? null,
+            })
+            continue
+          }
         }
+        this.store.recordBranchAssociation(target.repo, target.branch, pr?.number ?? target.pr_number, now)
         if (!pr) continue
         if (target.pr_number === pr.number) continue
 

--- a/src/daemon/watchers/integration.test.ts
+++ b/src/daemon/watchers/integration.test.ts
@@ -140,6 +140,53 @@ describe("watcher integration", () => {
     store.close()
   })
 
+
+  test("keeps a resolved PR attached until its merge snapshot is delivered", async () => {
+    const store = createStore()
+    const github = new FixtureGitHubClient()
+    const branchWatcher = new BranchDiscoveryWatcher(store, github)
+    const prWatcher = new PullRequestWatcher(store, github)
+
+    store.registerClient("client-merged", { pid: 2, projectRoot: "/tmp" })
+    store.registerSession({
+      clientId: "client-merged",
+      sessionId: "session-merged",
+      repo: "acme/repo",
+      branch: "feature/test",
+      isPrimary: true,
+      status: "active",
+      busyState: "idle",
+    })
+    store.recordBranchAssociation("acme/repo", "feature/test", 42)
+
+    github.pushSnapshot(makeSnapshot())
+    await prWatcher.tick()
+    const initialBatch = store.getPendingReminder("session-merged")
+    assert.ok(initialBatch)
+    store.ackReminder({
+      batchId: initialBatch.batchId,
+      sessionId: "session-merged",
+      state: "confirmed",
+    })
+
+
+    // The open-PR query no longer finds the PR after it merges, but that must
+    // not detach the existing session before the PR snapshot is diffed.
+    github.pushBranchResult(null)
+    await branchWatcher.tick()
+    assert.equal(store.getSession("session-merged")?.pr_number, 42)
+
+    const mergedSnapshot = makeSnapshot()
+    github.pushSnapshot({ ...mergedSnapshot, core: { ...mergedSnapshot.core, state: "MERGED" } })
+    await prWatcher.tick()
+
+    const batch = store.buildReminderBatch("session-merged")
+    assert.ok(batch)
+    assert.ok(batch.events.some((event) => event.kind === "pr.merged"))
+    assert.match(batch.reminderText, /Branch feature\/test was merged/)
+
+    store.close()
+  })
   test("PR watcher detects new comments and check failures across ticks", async () => {
     const store = createStore()
     const github = new FixtureGitHubClient()

--- a/src/daemon/watchers/integration.test.ts
+++ b/src/daemon/watchers/integration.test.ts
@@ -187,6 +187,99 @@ describe("watcher integration", () => {
 
     store.close()
   })
+
+  test("attaches a replacement session to a retained PR", async () => {
+    const store = createStore()
+    const github = new FixtureGitHubClient()
+    const branchWatcher = new BranchDiscoveryWatcher(store, github)
+    const prWatcher = new PullRequestWatcher(store, github)
+
+    store.registerClient("client-replacement", { pid: 3, projectRoot: "/tmp" })
+    store.registerSession({
+      clientId: "client-replacement",
+      sessionId: "session-before-replacement",
+      repo: "acme/repo",
+      branch: "feature/test",
+      isPrimary: true,
+      status: "active",
+      busyState: "idle",
+    })
+    store.recordBranchAssociation("acme/repo", "feature/test", 42)
+    github.pushSnapshot(makeSnapshot())
+    await prWatcher.tick()
+    const initialBatch = store.getPendingReminder("session-before-replacement")
+    assert.ok(initialBatch)
+    store.ackReminder({
+      batchId: initialBatch.batchId,
+      sessionId: "session-before-replacement",
+      state: "confirmed",
+    })
+
+    store.registerSession({
+      clientId: "client-replacement",
+      sessionId: "session-after-replacement",
+      repo: "acme/repo",
+      branch: "feature/test",
+      isPrimary: true,
+      status: "active",
+      busyState: "idle",
+    })
+    github.pushBranchResult(null)
+    await branchWatcher.tick()
+    assert.equal(store.getSession("session-after-replacement")?.pr_number, 42)
+
+    const mergedSnapshot = makeSnapshot()
+    github.pushSnapshot({ ...mergedSnapshot, core: { ...mergedSnapshot.core, state: "MERGED" } })
+    await prWatcher.tick()
+    const mergeBatch = store.getPendingReminder("session-after-replacement")
+    assert.ok(mergeBatch?.events.some((event) => event.kind === "pr.merged"))
+
+    store.close()
+  })
+
+  test("defers a new PR association until the previous PR reaches a terminal state", async () => {
+    const store = createStore()
+    const github = new FixtureGitHubClient()
+    const branchWatcher = new BranchDiscoveryWatcher(store, github)
+    const prWatcher = new PullRequestWatcher(store, github)
+
+    store.registerClient("client-reassociation", { pid: 4, projectRoot: "/tmp" })
+    store.registerSession({
+      clientId: "client-reassociation",
+      sessionId: "session-reassociation",
+      repo: "acme/repo",
+      branch: "feature/test",
+      isPrimary: true,
+      status: "active",
+      busyState: "idle",
+    })
+    store.recordBranchAssociation("acme/repo", "feature/test", 42)
+    github.pushSnapshot(makeSnapshot())
+    await prWatcher.tick()
+    const initialBatch = store.getPendingReminder("session-reassociation")
+    assert.ok(initialBatch)
+    store.ackReminder({
+      batchId: initialBatch.batchId,
+      sessionId: "session-reassociation",
+      state: "confirmed",
+    })
+
+    const nextPr = { number: 43, title: "Replacement PR", url: "https://github.com/acme/repo/pull/43", draft: false, state: "open" }
+    github.pushBranchResult(nextPr)
+    await branchWatcher.tick()
+    assert.equal(store.getSession("session-reassociation")?.pr_number, 42)
+
+    const mergedSnapshot = makeSnapshot()
+    github.pushSnapshot({ ...mergedSnapshot, core: { ...mergedSnapshot.core, state: "MERGED" } })
+    await prWatcher.tick()
+    assert.ok(store.getPendingReminder("session-reassociation")?.events.some((event) => event.kind === "pr.merged"))
+
+    github.pushBranchResult(nextPr)
+    await branchWatcher.tick()
+    assert.equal(store.getSession("session-reassociation")?.pr_number, 43)
+
+    store.close()
+  })
   test("PR watcher detects new comments and check failures across ticks", async () => {
     const store = createStore()
     const github = new FixtureGitHubClient()

--- a/src/daemon/watchers/pr-watcher.ts
+++ b/src/daemon/watchers/pr-watcher.ts
@@ -79,7 +79,6 @@ export class PullRequestWatcher {
         // Real changes landed — reset adaptive cadence to the active tier.
         this.schedule?.recordActivity(key, now)
 
-        this.store.insertEvents(target.repo, target.pr_number, events, now)
         const sessions = this.store.listSessionsForPr(target.repo, target.pr_number)
         for (const session of sessions) {
           this.store.buildReminderBatch(session.session_id, now)

--- a/src/daemon/watchers/pr-watcher.ts
+++ b/src/daemon/watchers/pr-watcher.ts
@@ -71,7 +71,7 @@ export class PullRequestWatcher {
         }
         const events = diffSnapshot(previous, next)
 
-        this.store.saveSnapshot(target.repo, target.pr_number, next)
+        this.store.saveSnapshotAndEvents(target.repo, target.pr_number, next, events, now)
         this.store.saveEtag(PR_SNAPSHOT_ETAG_SCOPE, etagKey(target.repo, target.pr_number), result.etag, now)
 
         if (events.length === 0) continue


### PR DESCRIPTION
## Summary
- emit durable high-priority `pr.merged` reminders from PR snapshot state
- retain branch associations through merge detection and safely defer replacement-PR reassociation
- atomically persist snapshots and events, with coverage for restarts and replacement sessions

## Validation
- `bun run check`
- `bun run test` (206 passing)

Closes #8

_(Drafted by Jacob's coding agent on his behalf)_