### PR TITLE
Reconcile check.failed against current HEAD, tame cancellation churn

### DIFF
--- a/src/daemon/github/diff.test.ts
+++ b/src/daemon/github/diff.test.ts
@@ -408,4 +408,38 @@ describe("diffSnapshot", () => {
     assert.notEqual(firstMerge.dedupeKey, secondMerge.dedupeKey)
   })
 
+  test("maps a cancelled check conclusion to check.cancelled at low priority, not check.created", () => {
+    const previous: PullRequestSnapshot = {
+      ...baseSnapshot(),
+      checks: [{ name: "ai-review", state: "queued" }],
+    }
+    const next: PullRequestSnapshot = {
+      ...previous,
+      checks: [{ name: "ai-review", state: "cancelled", link: "https://ci.example/ai-review" }],
+    }
+
+    const cancelled = diffSnapshot(previous, next).find((event) => event.kind === "check.cancelled")
+
+    assert.ok(cancelled)
+    assert.equal(cancelled.priority, "low")
+    assert.match(cancelled.summary, /cancelled/i)
+    assert.ok(!diffSnapshot(previous, next).some((event) => event.kind === "check.created"))
+  })
+
+  test("tags check events with the head SHA they were observed on", () => {
+    const previous: PullRequestSnapshot = {
+      ...baseSnapshot(),
+      checks: [{ name: "build", state: "queued" }],
+    }
+    const next: PullRequestSnapshot = {
+      ...previous,
+      core: { ...previous.core, headRefOid: "sha-2" },
+      checks: [{ name: "build", state: "fail", link: "https://ci.example/build" }],
+    }
+
+    const failed = diffSnapshot(previous, next).find((event) => event.kind === "check.failed")
+
+    assert.ok(failed)
+    assert.equal(failed.payload.headSha, "sha-2")
+  })
 })

--- a/src/daemon/github/diff.test.ts
+++ b/src/daemon/github/diff.test.ts
@@ -442,4 +442,70 @@ describe("diffSnapshot", () => {
     assert.ok(failed)
     assert.equal(failed.payload.headSha, "sha-2")
   })
+
+  test("an active rerun of a check supersedes a stale failure of the same name in the same tick", () => {
+    const previous: PullRequestSnapshot = {
+      ...baseSnapshot(),
+      checks: [{ name: "ai-review", state: "queued" }],
+    }
+    // Two check-runs named "ai-review" show up in the same rollup: the old
+    // run's failure from a race, and a fresh run already back in progress.
+    const next: PullRequestSnapshot = {
+      ...previous,
+      checks: [
+        { name: "ai-review", state: "fail", link: "https://ci.example/old-run" },
+        { name: "ai-review", state: "in_progress", link: "https://ci.example/new-run" },
+      ],
+    }
+
+    const events = diffSnapshot(previous, next)
+    const aiReviewEvents = events.filter((event) => event.payload.name === "ai-review")
+
+    assert.equal(aiReviewEvents.length, 1)
+    assert.equal(aiReviewEvents[0]!.kind, "check.in_progress")
+  })
+
+  test("a failing aggregate gate is treated as a cancellation artifact when a sibling in its workflow was cancelled", () => {
+    const previous: PullRequestSnapshot = {
+      ...baseSnapshot(),
+      checks: [
+        { name: "unit-tests (shard 1)", state: "cancelled", workflow: "CI" },
+        { name: "Fail if any shard failed", state: "queued", workflow: "CI" },
+      ],
+    }
+    const next: PullRequestSnapshot = {
+      ...previous,
+      checks: [
+        // unit-tests stays cancelled (no state change, so it emits no event
+        // of its own this tick — only the gate's state actually changes).
+        { name: "unit-tests (shard 1)", state: "cancelled", workflow: "CI" },
+        { name: "Fail if any shard failed", state: "fail", workflow: "CI", link: "https://ci.example/gate" },
+      ],
+    }
+
+    const events = diffSnapshot(previous, next)
+    const gate = events.find((event) => event.payload.name === "Fail if any shard failed")
+
+    assert.ok(gate)
+    assert.equal(gate.kind, "check.cancelled")
+    assert.equal(gate.priority, "low")
+    assert.match(gate.summary, /cancelled/i)
+  })
+
+  test("a genuine failure in a workflow with no cancellations stays check.failed", () => {
+    const previous: PullRequestSnapshot = {
+      ...baseSnapshot(),
+      checks: [{ name: "unit-tests", state: "queued", workflow: "CI" }],
+    }
+    const next: PullRequestSnapshot = {
+      ...previous,
+      checks: [{ name: "unit-tests", state: "fail", workflow: "CI", link: "https://ci.example/unit" }],
+    }
+
+    const failed = diffSnapshot(previous, next).find((event) => event.payload.name === "unit-tests")
+
+    assert.ok(failed)
+    assert.equal(failed.kind, "check.failed")
+    assert.equal(failed.priority, "high")
+  })
 })

--- a/src/daemon/github/diff.test.ts
+++ b/src/daemon/github/diff.test.ts
@@ -509,6 +509,61 @@ describe("diffSnapshot", () => {
     assert.equal(failed.priority, "high")
   })
 
+  test("does not mask an unrelated job's real failure just because something else in the workflow was cancelled", () => {
+    // "docs-build" fails for a real reason; "lint" happens to be cancelled in
+    // the same workflow for an unrelated reason. Neither name looks like an
+    // aggregate gate, so this must stay check.failed — the old (broken)
+    // heuristic keyed only on workflow name and would have masked this.
+    const previous: PullRequestSnapshot = {
+      ...baseSnapshot(),
+      checks: [
+        { name: "docs-build", state: "queued", workflow: "CI" },
+        { name: "lint", state: "queued", workflow: "CI" },
+      ],
+    }
+    const next: PullRequestSnapshot = {
+      ...previous,
+      checks: [
+        { name: "docs-build", state: "fail", workflow: "CI", link: "https://ci.example/docs" },
+        { name: "lint", state: "cancelled", workflow: "CI" },
+      ],
+    }
+
+    const failed = diffSnapshot(previous, next).find((event) => event.payload.name === "docs-build")
+
+    assert.ok(failed)
+    assert.equal(failed.kind, "check.failed")
+    assert.equal(failed.priority, "high")
+  })
+
+  test("does not mask a real matrix-shard failure whose siblings were fail-fast cancelled, even if it's named like a gate", () => {
+    // fail-fast is GitHub Actions' default for matrix strategies: shard 1
+    // fails for real and GitHub cancels shards 2/3 as a normal consequence.
+    // Even though "required-checks (shard 1)" matches the gate name pattern,
+    // it's part of a matrix group (matrixGroup.length > 1), so the
+    // cancellation heuristic must never apply to it.
+    const previous: PullRequestSnapshot = {
+      ...baseSnapshot(),
+      checks: [
+        { name: "required-checks (shard 1)", state: "queued", workflow: "CI" },
+        { name: "required-checks (shard 2)", state: "queued", workflow: "CI" },
+      ],
+    }
+    const next: PullRequestSnapshot = {
+      ...previous,
+      checks: [
+        { name: "required-checks (shard 1)", state: "fail", workflow: "CI", link: "https://ci.example/shard-1" },
+        { name: "required-checks (shard 2)", state: "cancelled", workflow: "CI" },
+      ],
+    }
+
+    const failed = diffSnapshot(previous, next).find((event) => event.payload.name === "required-checks (shard 1)")
+
+    assert.ok(failed)
+    assert.equal(failed.kind, "check.failed")
+    assert.equal(failed.priority, "high")
+  })
+
   test("stays quiet when a matrix shard succeeds while sibling shards are still running", () => {
     const previous: PullRequestSnapshot = {
       ...baseSnapshot(),

--- a/src/daemon/github/diff.test.ts
+++ b/src/daemon/github/diff.test.ts
@@ -508,4 +508,111 @@ describe("diffSnapshot", () => {
     assert.equal(failed.kind, "check.failed")
     assert.equal(failed.priority, "high")
   })
+
+  test("stays quiet when a matrix shard succeeds while sibling shards are still running", () => {
+    const previous: PullRequestSnapshot = {
+      ...baseSnapshot(),
+      checks: [
+        { name: "unit-tests (shard 1)", state: "queued", workflow: "CI" },
+        { name: "unit-tests (shard 2)", state: "queued", workflow: "CI" },
+      ],
+    }
+    const next: PullRequestSnapshot = {
+      ...previous,
+      checks: [
+        { name: "unit-tests (shard 1)", state: "success", workflow: "CI" },
+        { name: "unit-tests (shard 2)", state: "in_progress", workflow: "CI" },
+      ],
+    }
+
+    const events = diffSnapshot(previous, next)
+
+    assert.ok(!events.some((event) => event.payload.name === "unit-tests (shard 1)"))
+  })
+
+  test("rolls a matrix job up into one summary once every shard finishes green", () => {
+    const previous: PullRequestSnapshot = {
+      ...baseSnapshot(),
+      checks: [
+        { name: "unit-tests (shard 1)", state: "success", workflow: "CI" },
+        { name: "unit-tests (shard 2)", state: "in_progress", workflow: "CI" },
+      ],
+    }
+    const next: PullRequestSnapshot = {
+      ...previous,
+      checks: [
+        { name: "unit-tests (shard 1)", state: "success", workflow: "CI" },
+        { name: "unit-tests (shard 2)", state: "success", workflow: "CI" },
+      ],
+    }
+
+    const events = diffSnapshot(previous, next)
+    const rollup = events.find((event) => event.kind === "check.succeeded")
+
+    assert.ok(rollup)
+    assert.match(rollup.summary, /2\/2 shards succeeded: unit-tests/)
+    assert.ok(!events.some((event) => event.payload.name === "unit-tests (shard 1)" && event !== rollup))
+  })
+
+  test("still reports a failing shard immediately while sibling shards are still running", () => {
+    const previous: PullRequestSnapshot = {
+      ...baseSnapshot(),
+      checks: [
+        { name: "unit-tests (shard 1)", state: "queued", workflow: "CI" },
+        { name: "unit-tests (shard 2)", state: "queued", workflow: "CI" },
+      ],
+    }
+    const next: PullRequestSnapshot = {
+      ...previous,
+      checks: [
+        { name: "unit-tests (shard 1)", state: "fail", workflow: "CI", link: "https://ci.example/shard-1" },
+        { name: "unit-tests (shard 2)", state: "in_progress", workflow: "CI" },
+      ],
+    }
+
+    const failed = diffSnapshot(previous, next).find((event) => event.payload.name === "unit-tests (shard 1)")
+
+    assert.ok(failed)
+    assert.equal(failed.kind, "check.failed")
+    assert.equal(failed.priority, "high")
+  })
+
+  test("does not re-announce remaining shards once a sibling in the same matrix job already failed", () => {
+    const previous: PullRequestSnapshot = {
+      ...baseSnapshot(),
+      checks: [
+        { name: "unit-tests (shard 1)", state: "fail", workflow: "CI" },
+        { name: "unit-tests (shard 2)", state: "in_progress", workflow: "CI" },
+      ],
+    }
+    const next: PullRequestSnapshot = {
+      ...previous,
+      checks: [
+        { name: "unit-tests (shard 1)", state: "fail", workflow: "CI" },
+        { name: "unit-tests (shard 2)", state: "success", workflow: "CI" },
+      ],
+    }
+
+    const events = diffSnapshot(previous, next)
+
+    assert.ok(!events.some((event) => event.payload.name === "unit-tests (shard 2)"))
+  })
+
+  test("suppresses per-shard started/queued noise for matrix jobs", () => {
+    const previous: PullRequestSnapshot = {
+      ...baseSnapshot(),
+      checks: [{ name: "unit-tests (shard 1)", state: "queued", workflow: "CI" }],
+    }
+    const next: PullRequestSnapshot = {
+      ...previous,
+      checks: [
+        { name: "unit-tests (shard 1)", state: "in_progress", workflow: "CI" },
+        { name: "unit-tests (shard 2)", state: "queued", workflow: "CI" },
+      ],
+    }
+
+    const events = diffSnapshot(previous, next)
+
+    assert.equal(events.length, 0)
+  })
 })

--- a/src/daemon/github/diff.ts
+++ b/src/daemon/github/diff.ts
@@ -15,6 +15,7 @@ const checkKind = (state?: string) => {
   const normalized = (state ?? "").toLowerCase()
   if (["pass", "success", "succeeded"].includes(normalized)) return "check.succeeded"
   if (["fail", "failed", "failure"].includes(normalized)) return "check.failed"
+  if (["cancelled", "canceled"].includes(normalized)) return "check.cancelled"
   if (["pending", "queued"].includes(normalized)) return "check.queued"
   if (["running", "in_progress"].includes(normalized)) return "check.in_progress"
   return "check.created"
@@ -30,6 +31,7 @@ const checkSummary = (check: PullRequestCheck, kind: string) => {
   const name = check.name || "unnamed check"
   if (kind === "check.failed") return `Check failed: ${name}`
   if (kind === "check.succeeded") return `Check passed: ${name}`
+  if (kind === "check.cancelled") return `Check cancelled: ${name}`
   if (kind === "check.in_progress") return `Check started: ${name}`
   if (kind === "check.queued") return `Check queued: ${name}`
   return `New check detected: ${name}`
@@ -52,6 +54,7 @@ const groupKinds = new Set([
   "check.in_progress",
   "check.succeeded",
   "check.failed",
+  "check.cancelled",
   "issue_comment.created",
   "issue_comment.edited",
   "issue_comment.deleted",
@@ -461,6 +464,7 @@ export function diffSnapshot(previous: PullRequestSnapshot | null, next: PullReq
         state: check.state ?? null,
         workflow: check.workflow ?? null,
         event: check.event ?? null,
+        headSha: next.core.headRefOid,
       },
     })
   }

--- a/src/daemon/github/diff.ts
+++ b/src/daemon/github/diff.ts
@@ -484,6 +484,26 @@ export function diffSnapshot(previous: PullRequestSnapshot | null, next: PullReq
     if (checkKind(check.state) === "check.cancelled" && check.workflow) cancelledWorkflows.add(check.workflow)
   }
 
+  // Matrix/shard jobs ("unit-tests (shard 1)", "test (ubuntu-latest)", ...) are
+  // detected by stripping a trailing "(...)"/"[...]" segment from the name;
+  // checks in the same workflow that reduce to the same base name are treated
+  // as one job's shards. Quiet on green: an individual shard turning green
+  // while siblings are still running is not worth waking the agent for, and
+  // is rolled up into one summary once the whole job finishes clean. Loud on
+  // first red: a failing shard is always reported immediately, uncondensed,
+  // so the agent can start fixing it without waiting on the rest.
+  const matrixBaseName = (name: string) => name.replace(/\s*[([][^()[\]]*[)\]]\s*$/, "").trim() || name
+  const matrixGroupKey = (check: PullRequestCheck) => `${check.workflow ?? ""}::${matrixBaseName(check.name)}`
+  const groupsByMatrixKey = new Map<string, PullRequestCheck[]>()
+  for (const checks of nextChecksByName.values()) {
+    const representative = representativeCheck(checks)
+    const key = matrixGroupKey(representative)
+    const bucket = groupsByMatrixKey.get(key)
+    if (bucket) bucket.push(representative)
+    else groupsByMatrixKey.set(key, [representative])
+  }
+  const TERMINAL_CHECK_KINDS = new Set(["check.succeeded", "check.failed", "check.cancelled"])
+
   for (const checks of nextChecksByName.values()) {
     const check = representativeCheck(checks)
     const prev = previousChecks.get(check.name)
@@ -494,6 +514,21 @@ export function diffSnapshot(previous: PullRequestSnapshot | null, next: PullReq
     if (kind === "check.failed" && check.workflow && cancelledWorkflows.has(check.workflow)) {
       kind = "check.cancelled"
       summary = `Check cancelled (a sibling job in the same workflow run was cancelled): ${check.name || "unnamed check"}`
+    }
+
+    const matrixGroup = groupsByMatrixKey.get(matrixGroupKey(check)) ?? [check]
+    if (matrixGroup.length > 1) {
+      if (kind === "check.succeeded") {
+        const allTerminal = matrixGroup.every((sibling) => TERMINAL_CHECK_KINDS.has(checkKind(sibling.state)))
+        const anyFailed = matrixGroup.some((sibling) => checkKind(sibling.state) === "check.failed")
+        if (!allTerminal) continue // other shards still running — stay quiet
+        if (anyFailed) continue // a red shard already got its own loud event
+        summary = `${matrixGroup.length}/${matrixGroup.length} shards succeeded: ${matrixBaseName(check.name)}`
+      } else if (kind === "check.in_progress" || kind === "check.queued" || kind === "check.created") {
+        continue // per-shard start/queue noise — only a red shard is worth surfacing
+      }
+      // check.failed and check.cancelled always fall through and are reported
+      // immediately, uncondensed — loud on first red.
     }
 
     events.push({

--- a/src/daemon/github/diff.ts
+++ b/src/daemon/github/diff.ts
@@ -467,18 +467,27 @@ export function diffSnapshot(previous: PullRequestSnapshot | null, next: PullReq
     if (checks.length === 1) return checks[0]!
     const active = checks.find((check) => ACTIVE_CHECK_KINDS.has(checkKind(check.state)))
     if (active) return active
-    // Multiple terminal results with no active rerun (rare) — prefer the
-    // worst outcome so a real failure never loses to a stale duplicate.
+    // Multiple terminal results with no active rerun (rare) — prefer a
+    // failed one over any other terminal kind so a real failure never loses
+    // to a stale success/cancellation. This is NOT a full best-to-worst
+    // ranking of every terminal kind: among non-failed duplicates (e.g. two
+    // "success" entries, or a "success" and a "cancelled" with no failure),
+    // the pick falls through to array order, which is arbitrary.
     return checks.find((check) => checkKind(check.state) === "check.failed") ?? checks[checks.length - 1]!
   }
 
-  // Correlate failures with sibling cancellations in the same workflow run.
-  // An aggregate gate (e.g. "Fail if any shard failed") often reports its
-  // own conclusion as FAILURE when a prerequisite job was cancelled by a
-  // concurrency group, rather than because any assertion actually failed.
-  // We don't have step-level output, so this is a best-effort heuristic:
-  // if any check in the same workflow was cancelled this tick, treat a
-  // sibling failure in that workflow as a cancellation artifact too.
+  // Correlate failures with sibling cancellations in the same workflow run,
+  // but ONLY for jobs that look like an aggregate gate ("Fail if any shard
+  // failed", "Required checks", ...). Those jobs commonly report their own
+  // conclusion as FAILURE when a prerequisite was cancelled by a concurrency
+  // group, rather than because any assertion actually failed — and we don't
+  // have step-level output to confirm that directly, so this is a
+  // best-effort, deliberately narrow heuristic. It must NOT match ordinary
+  // job names: a matrix shard failing for real routinely has its siblings
+  // cancelled by fail-fast, and an unrelated job failing for real can share
+  // a workflow with an unrelated cancellation — neither should ever be
+  // masked as a cancellation artifact.
+  const AGGREGATE_GATE_NAME_PATTERN = /\b(gate|required|fail[- ]?if|overall|rollup)\b/i
   const cancelledWorkflows = new Set<string>()
   for (const check of next.checks) {
     if (checkKind(check.state) === "check.cancelled" && check.workflow) cancelledWorkflows.add(check.workflow)
@@ -492,6 +501,14 @@ export function diffSnapshot(previous: PullRequestSnapshot | null, next: PullReq
   // is rolled up into one summary once the whole job finishes clean. Loud on
   // first red: a failing shard is always reported immediately, uncondensed,
   // so the agent can start fixing it without waiting on the rest.
+  //
+  // Known limitation: group membership (and therefore "allTerminal"/shard
+  // count) is recomputed from next.checks on every tick with no memory of
+  // prior ticks. If GitHub's rollup transiently drops a shard and it later
+  // reappears (dynamic matrix, re-dispatch, a flaky API response), the
+  // "N/N shards succeeded" rollup could fire once with an undercount and
+  // again later with the corrected count. This is considered an acceptable,
+  // rare edge case rather than something worth persisting group state for.
   const matrixBaseName = (name: string) => name.replace(/\s*[([][^()[\]]*[)\]]\s*$/, "").trim() || name
   const matrixGroupKey = (check: PullRequestCheck) => `${check.workflow ?? ""}::${matrixBaseName(check.name)}`
   const groupsByMatrixKey = new Map<string, PullRequestCheck[]>()
@@ -511,10 +528,6 @@ export function diffSnapshot(previous: PullRequestSnapshot | null, next: PullReq
 
     let kind = checkKind(check.state)
     let summary = checkSummary(check, kind)
-    if (kind === "check.failed" && check.workflow && cancelledWorkflows.has(check.workflow)) {
-      kind = "check.cancelled"
-      summary = `Check cancelled (a sibling job in the same workflow run was cancelled): ${check.name || "unnamed check"}`
-    }
 
     const matrixGroup = groupsByMatrixKey.get(matrixGroupKey(check)) ?? [check]
     if (matrixGroup.length > 1) {
@@ -528,7 +541,21 @@ export function diffSnapshot(previous: PullRequestSnapshot | null, next: PullReq
         continue // per-shard start/queue noise — only a red shard is worth surfacing
       }
       // check.failed and check.cancelled always fall through and are reported
-      // immediately, uncondensed — loud on first red.
+      // immediately, uncondensed — loud on first red. A real matrix-shard
+      // failure must never be downgraded by the cancellation heuristic below
+      // (fail-fast routinely cancels its siblings), so that heuristic only
+      // ever applies to a standalone job (matrixGroup.length === 1).
+    }
+
+    if (
+      kind === "check.failed" &&
+      matrixGroup.length === 1 &&
+      check.workflow &&
+      cancelledWorkflows.has(check.workflow) &&
+      AGGREGATE_GATE_NAME_PATTERN.test(check.name)
+    ) {
+      kind = "check.cancelled"
+      summary = `Check cancelled (a sibling job in the same workflow run was cancelled): ${check.name || "unnamed check"}`
     }
 
     events.push({

--- a/src/daemon/github/diff.ts
+++ b/src/daemon/github/diff.ts
@@ -449,15 +449,58 @@ export function diffSnapshot(previous: PullRequestSnapshot | null, next: PullReq
   }
 
   const previousChecks = new Map(previous.checks.map((check) => [check.name, check]))
+
+  // GitHub's statusCheckRollup can list more than one check-run per name in
+  // the same poll tick when two runs raced on this commit (e.g. a push and a
+  // label event both triggering CI). Group by name so a stale fail/cancelled
+  // entry never wins over an active rerun of the same check that's already
+  // in flight.
+  const nextChecksByName = new Map<string, PullRequestCheck[]>()
   for (const check of next.checks) {
+    const bucket = nextChecksByName.get(check.name)
+    if (bucket) bucket.push(check)
+    else nextChecksByName.set(check.name, [check])
+  }
+
+  const ACTIVE_CHECK_KINDS = new Set(["check.in_progress", "check.queued", "check.created"])
+  const representativeCheck = (checks: PullRequestCheck[]): PullRequestCheck => {
+    if (checks.length === 1) return checks[0]!
+    const active = checks.find((check) => ACTIVE_CHECK_KINDS.has(checkKind(check.state)))
+    if (active) return active
+    // Multiple terminal results with no active rerun (rare) — prefer the
+    // worst outcome so a real failure never loses to a stale duplicate.
+    return checks.find((check) => checkKind(check.state) === "check.failed") ?? checks[checks.length - 1]!
+  }
+
+  // Correlate failures with sibling cancellations in the same workflow run.
+  // An aggregate gate (e.g. "Fail if any shard failed") often reports its
+  // own conclusion as FAILURE when a prerequisite job was cancelled by a
+  // concurrency group, rather than because any assertion actually failed.
+  // We don't have step-level output, so this is a best-effort heuristic:
+  // if any check in the same workflow was cancelled this tick, treat a
+  // sibling failure in that workflow as a cancellation artifact too.
+  const cancelledWorkflows = new Set<string>()
+  for (const check of next.checks) {
+    if (checkKind(check.state) === "check.cancelled" && check.workflow) cancelledWorkflows.add(check.workflow)
+  }
+
+  for (const checks of nextChecksByName.values()) {
+    const check = representativeCheck(checks)
     const prev = previousChecks.get(check.name)
-    const kind = checkKind(check.state)
     if (prev && prev.state === check.state) continue
+
+    let kind = checkKind(check.state)
+    let summary = checkSummary(check, kind)
+    if (kind === "check.failed" && check.workflow && cancelledWorkflows.has(check.workflow)) {
+      kind = "check.cancelled"
+      summary = `Check cancelled (a sibling job in the same workflow run was cancelled): ${check.name || "unnamed check"}`
+    }
+
     events.push({
       dedupeKey: `${kind}:${check.name}:${next.core.headRefOid}`,
       kind,
       priority: checkPriority(kind),
-      summary: checkSummary(check, kind),
+      summary,
       referenceLink: check.link ?? next.core.url,
       payload: {
         name: check.name,

--- a/src/daemon/persistence/store.test.ts
+++ b/src/daemon/persistence/store.test.ts
@@ -88,7 +88,7 @@ describe("StateStore", () => {
     assert.equal(batch.events.length, 2)
     assert.match(
       batch.reminderText,
-      /Action required: investigate and address the failing checks or merge conflicts above/,
+      /Action required: resolve the failing check\(s\)\/merge conflict\(s\) on HEAD before continuing/,
     )
 
     const pending = store.getPendingReminder("session-1")
@@ -98,6 +98,130 @@ describe("StateStore", () => {
 
     assert.equal(store.getPendingReminder("session-1"), null)
     assert.equal(store.buildReminderBatch("session-1"), null)
+
+    store.close()
+  })
+
+  test("supersedes check.failed/check.cancelled events from a replaced commit into one low-priority summary", () => {
+    const store = createStore()
+
+    store.registerClient("client-1", { pid: 123, projectRoot: "/tmp/project" })
+    store.registerSession({
+      clientId: "client-1",
+      sessionId: "session-1",
+      repo: "acme/repo",
+      branch: "feature/x",
+      isPrimary: true,
+      status: "active",
+      busyState: "idle",
+    })
+    store.recordBranchAssociation("acme/repo", "feature/x", 7)
+    // The PR has already moved on to sha-new; these events were recorded
+    // while sha-old was still HEAD (e.g. before the agent pushed a fix).
+    store.saveSnapshot("acme/repo", 7, { ...snapshot(), core: { ...snapshot().core, headRefOid: "sha-new" } })
+    store.insertEvents("acme/repo", 7, [
+      {
+        dedupeKey: "check.failed:lint:sha-old",
+        kind: "check.failed",
+        priority: "high",
+        summary: "Check failed: lint",
+        payload: { name: "lint", headSha: "sha-old" },
+      },
+      {
+        dedupeKey: "check.cancelled:build:sha-old",
+        kind: "check.cancelled",
+        priority: "low",
+        summary: "Check cancelled: build",
+        payload: { name: "build", headSha: "sha-old" },
+      },
+    ])
+
+    const batch = store.buildReminderBatch("session-1")
+    assert.ok(batch)
+    assert.equal(batch.events.length, 1)
+    assert.equal(batch.events[0]!.kind, "check.superseded")
+    assert.match(batch.events[0]!.summary, /1 failed, 1 cancelled on sha-old \(superseded by sha-new\)/)
+    assert.doesNotMatch(batch.reminderText, /Changes:/)
+    assert.match(batch.reminderText, /Superseded:/)
+    assert.doesNotMatch(batch.reminderText, /Action required/)
+
+    store.close()
+  })
+
+  test("keeps a live check.failed on HEAD actionable while a superseded one from the prior commit is summarized", () => {
+    const store = createStore()
+
+    store.registerClient("client-1", { pid: 123, projectRoot: "/tmp/project" })
+    store.registerSession({
+      clientId: "client-1",
+      sessionId: "session-1",
+      repo: "acme/repo",
+      branch: "feature/x",
+      isPrimary: true,
+      status: "active",
+      busyState: "idle",
+    })
+    store.recordBranchAssociation("acme/repo", "feature/x", 7)
+    store.saveSnapshot("acme/repo", 7, { ...snapshot(), core: { ...snapshot().core, headRefOid: "sha-new" } })
+    store.insertEvents("acme/repo", 7, [
+      {
+        dedupeKey: "check.failed:lint:sha-old",
+        kind: "check.failed",
+        priority: "high",
+        summary: "Check failed: lint",
+        payload: { name: "lint", headSha: "sha-old" },
+      },
+      {
+        dedupeKey: "check.failed:build:sha-new",
+        kind: "check.failed",
+        priority: "high",
+        summary: "Check failed: build",
+        payload: { name: "build", headSha: "sha-new" },
+      },
+    ])
+
+    const batch = store.buildReminderBatch("session-1")
+    assert.ok(batch)
+    assert.equal(batch.events.length, 2)
+    assert.ok(batch.events.some((event) => event.kind === "check.failed" && event.summary.includes("build")))
+    assert.ok(batch.events.some((event) => event.kind === "check.superseded" && event.summary.includes("lint") === false))
+    assert.match(batch.reminderText, /Changes:\n1\. check\.failed - Check failed: build/)
+    assert.match(batch.reminderText, /Superseded:\n1\. check\.superseded - 1 failed on sha-old \(superseded by sha-new\)/)
+    assert.match(batch.reminderText, /Action required: resolve the failing check\(s\)\/merge conflict\(s\) on HEAD before continuing/)
+
+    store.close()
+  })
+
+  test("treats check.failed events with no recorded headSha as live (backward compatible)", () => {
+    const store = createStore()
+
+    store.registerClient("client-1", { pid: 123, projectRoot: "/tmp/project" })
+    store.registerSession({
+      clientId: "client-1",
+      sessionId: "session-1",
+      repo: "acme/repo",
+      branch: "feature/x",
+      isPrimary: true,
+      status: "active",
+      busyState: "idle",
+    })
+    store.recordBranchAssociation("acme/repo", "feature/x", 7)
+    store.saveSnapshot("acme/repo", 7, { ...snapshot(), core: { ...snapshot().core, headRefOid: "sha-new" } })
+    store.insertEvents("acme/repo", 7, [
+      {
+        dedupeKey: "check.failed:lint:unknown",
+        kind: "check.failed",
+        priority: "high",
+        summary: "Check failed: lint",
+        payload: { name: "lint" },
+      },
+    ])
+
+    const batch = store.buildReminderBatch("session-1")
+    assert.ok(batch)
+    assert.equal(batch.events.length, 1)
+    assert.equal(batch.events[0]!.kind, "check.failed")
+    assert.match(batch.reminderText, /Action required/)
 
     store.close()
   })
@@ -1444,7 +1568,7 @@ describe("StateStore", () => {
     assert.ok(staleBatch)
     assert.match(staleBatch.reminderText, /manually subscribed/)
     assert.match(staleBatch.reminderText, /Do not make changes unless the user explicitly asks/)
-    assert.match(staleBatch.reminderText, /wait for explicit authorization before making changes/)
+    assert.match(staleBatch.reminderText, /wait for authorization before making changes/)
     ;(store as any).db
       .prepare(`UPDATE session_subscriptions SET state = 'unsubscribed' WHERE subscription_id = ?`)
       .run(manual.subscriptionId)

--- a/src/daemon/persistence/store.ts
+++ b/src/daemon/persistence/store.ts
@@ -113,6 +113,7 @@ type EventRow = {
 	priority: "high" | "medium" | "low";
 	summary: string;
 	reference_link: string | null;
+	payload_json: string;
 };
 
 type GroupedReminderEvent = ReminderEvent & {
@@ -125,6 +126,15 @@ const priorityRank: Record<ReminderEvent["priority"], number> = {
 	medium: 1,
 	low: 2,
 };
+
+// Check kinds that only matter on the PR's current HEAD. A push supersedes
+// every check-run on the previous commit, and GitHub never retracts those
+// old check-runs — it just leaves them failed/cancelled forever. Without
+// this, an agent that already pushed a fix keeps getting "Action required"
+// reminders for commits it has already replaced.
+const SUPERSEDABLE_CHECK_KINDS = new Set(["check.failed", "check.cancelled"]);
+
+const shortSha = (sha: string) => sha.slice(0, 7);
 
 export class StateStore {
 	private readonly db: DatabaseSync;
@@ -1545,7 +1555,7 @@ export class StateStore {
 	) {
 		return this.db
 			.prepare(
-				`SELECT seq, kind, priority, summary, reference_link
+				`SELECT seq, kind, priority, summary, reference_link, payload_json
 				 FROM pr_events
 				 WHERE repo = :repo
 				   AND pr_number = :prNumber
@@ -1830,6 +1840,13 @@ export class StateStore {
 			(subscription.sessionId !== sessionId || subscription.state !== "active")
 		) return null;
 
+		const targetRepo = subscription?.repo ?? session.repo;
+		const targetPrNumber = subscription?.prNumber ?? session.pr_number;
+		const qualifiedTarget = targetPrNumber ? `${targetRepo}#${targetPrNumber}` : targetRepo;
+		const currentHeadSha = targetPrNumber
+			? this.getSnapshot(targetRepo, targetPrNumber)?.core.headRefOid
+			: undefined;
+
 		const existing = subscription
 			? this.getPendingReminderForSubscription(subscription.subscriptionId)
 			: this.getPendingReminder(sessionId);
@@ -1841,16 +1858,49 @@ export class StateStore {
 		if (events.length === 0) return null;
 		const maxEventSeq = events.at(-1)!.seq;
 
-		const reminderEvents: GroupedReminderEvent[] = events.map((event) => ({
-			eventId: String(event.seq),
-			kind: event.kind,
-			priority: event.priority,
-			summary: event.summary,
-			referenceLink: event.reference_link ?? undefined,
-		}));
+		const reminderEvents: Array<GroupedReminderEvent & { headSha?: string }> = events.map((event) => {
+			let headSha: string | undefined;
+			try {
+				const payload = JSON.parse(event.payload_json) as Record<string, unknown>;
+				if (typeof payload.headSha === "string") headSha = payload.headSha;
+			} catch {
+				// Malformed payload JSON should never block reminder delivery.
+			}
+			return {
+				eventId: String(event.seq),
+				kind: event.kind,
+				priority: event.priority,
+				summary: event.summary,
+				referenceLink: event.reference_link ?? undefined,
+				...(headSha ? { headSha } : {}),
+			};
+		});
+
+		// Option C: a check.failed/check.cancelled event whose headSha no longer
+		// matches the PR's current HEAD cannot be fixed directly — the commit it
+		// ran on is already gone. Pull those out before grouping so they never
+		// reach the live "Changes" list or the actionable-blocker check; they
+		// are summarized once per superseded commit instead (see below).
+		const liveEvents: GroupedReminderEvent[] = [];
+		const supersededByHeadSha = new Map<string, GroupedReminderEvent[]>();
+		for (const event of reminderEvents) {
+			const { headSha, ...reminderEvent } = event;
+			const isSuperseded =
+				currentHeadSha !== undefined &&
+				headSha !== undefined &&
+				headSha !== currentHeadSha &&
+				SUPERSEDABLE_CHECK_KINDS.has(reminderEvent.kind);
+			if (isSuperseded) {
+				const bucket = supersededByHeadSha.get(headSha);
+				if (bucket) bucket.push(reminderEvent);
+				else supersededByHeadSha.set(headSha, [reminderEvent]);
+				continue;
+			}
+			liveEvents.push(reminderEvent);
+		}
 
 		const grouped = new Map<string, GroupedReminderEvent[]>();
-		for (const event of reminderEvents) {
+		for (const event of liveEvents) {
 			const key =
 				event.priority === "low" || event.priority === "medium"
 					? `${event.priority}:${event.kind}`
@@ -1860,7 +1910,7 @@ export class StateStore {
 			else grouped.set(key, [event]);
 		}
 
-		const condensed = Array.from(grouped.values()).map((bucket) => {
+		const condensedLive = Array.from(grouped.values()).map((bucket) => {
 			if (bucket.length === 1 || bucket[0].priority === "high")
 				return bucket[0];
 			return {
@@ -1873,45 +1923,63 @@ export class StateStore {
 				samples: bucket.slice(0, 2).map((event) => event.summary),
 			};
 		});
-
-		condensed.sort((left, right) => {
+		condensedLive.sort((left, right) => {
 			const priorityDelta =
 				priorityRank[left.priority] - priorityRank[right.priority];
 			if (priorityDelta !== 0) return priorityDelta;
 			return Number(left.eventId) - Number(right.eventId);
 		});
+
+		// One informational line per superseded commit, e.g. "2 failed on 03f8a47
+		// (superseded by 87c8827)" — never an actionable blocker, never repeated
+		// per check.
+		const supersededSummaries: GroupedReminderEvent[] = Array.from(supersededByHeadSha.entries()).map(
+			([oldHeadSha, bucket]) => {
+				const failedCount = bucket.filter((event) => event.kind === "check.failed").length;
+				const cancelledCount = bucket.filter((event) => event.kind === "check.cancelled").length;
+				const parts: string[] = [];
+				if (failedCount > 0) parts.push(`${failedCount} failed`);
+				if (cancelledCount > 0) parts.push(`${cancelledCount} cancelled`);
+				const description = parts.join(", ") || `${bucket.length} check${bucket.length === 1 ? "" : "s"} resolved`;
+				return {
+					eventId: bucket.at(-1)!.eventId,
+					kind: "check.superseded",
+					priority: "low" as const,
+					summary: `${description} on ${shortSha(oldHeadSha)}${currentHeadSha ? ` (superseded by ${shortSha(currentHeadSha)})` : ""}`,
+					count: bucket.length,
+				};
+			},
+		);
+
+		const condensed = [...condensedLive, ...supersededSummaries];
 		const hasActionableBlocker = condensed.some((event) =>
 			["check.failed", "merge_conflict.detected"].includes(event.kind),
 		);
-		const targetRepo = subscription?.repo ?? session.repo;
-		const targetPrNumber = subscription?.prNumber ?? session.pr_number;
-		const qualifiedTarget = targetPrNumber ? `${targetRepo}#${targetPrNumber}` : targetRepo;
+		const renderEvent = (event: GroupedReminderEvent, index: number) =>
+			`${index + 1}. ${event.kind} - ${event.summary}${event.referenceLink ? ` (${event.referenceLink})` : ""}`;
 		const reminderText = [
 			"<system-reminder>",
-			`New pull request context was detected for ${qualifiedTarget} since the last reminder.`,
+			currentHeadSha
+				? `PR update for ${qualifiedTarget} (HEAD: ${shortSha(currentHeadSha)}):`
+				: `PR update for ${qualifiedTarget}:`,
 			...(subscription?.source === "manual"
 				? [
 					"",
 					"This PR is manually subscribed. Do not make changes unless the user explicitly asks you to.",
 				]
 				: []),
-			"",
-			"Changes:",
-			...condensed.map(
-
-				(event, index) =>
-					`${index + 1}. ${event.kind} - ${event.summary}${event.referenceLink ? ` (${event.referenceLink})` : ""}`,
-			),
+			...(condensedLive.length > 0 ? ["", "Changes:", ...condensedLive.map(renderEvent)] : []),
+			...(supersededSummaries.length > 0 ? ["", "Superseded:", ...supersededSummaries.map(renderEvent)] : []),
 			...(hasActionableBlocker
 				? [
 					"",
 					subscription?.source === "manual"
-						? "Action required: report the failing checks or merge conflicts above to the user and wait for explicit authorization before making changes."
-						: "Action required: investigate and address the failing checks or merge conflicts above before continuing the current task. If you cannot resolve them, explain why.",
+						? "Action required: report the failing check(s)/merge conflict(s) above and wait for authorization before making changes."
+						: "Action required: resolve the failing check(s)/merge conflict(s) on HEAD before continuing. If you can't, explain why.",
 				]
 				: []),
 			"",
-			"Please incorporate only the new information above into your reasoning and continue the current task.",
+			"Incorporate only the above into your reasoning and continue.",
 			"</system-reminder>",
 		].join("\n");
 		const batchId = this.createOrReplaceReminder(

--- a/src/daemon/persistence/store.ts
+++ b/src/daemon/persistence/store.ts
@@ -1843,9 +1843,6 @@ export class StateStore {
 		const targetRepo = subscription?.repo ?? session.repo;
 		const targetPrNumber = subscription?.prNumber ?? session.pr_number;
 		const qualifiedTarget = targetPrNumber ? `${targetRepo}#${targetPrNumber}` : targetRepo;
-		const currentHeadSha = targetPrNumber
-			? this.getSnapshot(targetRepo, targetPrNumber)?.core.headRefOid
-			: undefined;
 
 		const existing = subscription
 			? this.getPendingReminderForSubscription(subscription.subscriptionId)
@@ -1857,6 +1854,9 @@ export class StateStore {
 			: this.listUndeliveredEvents(sessionId);
 		if (events.length === 0) return null;
 		const maxEventSeq = events.at(-1)!.seq;
+		const currentHeadSha = targetPrNumber
+			? this.getSnapshot(targetRepo, targetPrNumber)?.core.headRefOid
+			: undefined;
 
 		const reminderEvents: Array<GroupedReminderEvent & { headSha?: string }> = events.map((event) => {
 			let headSha: string | undefined;


### PR DESCRIPTION
## Problem

Every push starts fresh CI on the new commit and GitHub cancels in-flight runs on the previous one. premind's watcher stores a `check.failed` event for each failing/cancelled check-run it sees, but never reconciles it against the PR's current HEAD before surfacing it. An agent that has already pushed a fix keeps getting "Action required" reminders for checks that ran on commits it already replaced — each one costing a verify-and-dismiss turn (`git rev-parse HEAD` + `gh api .../check-runs`) for zero code outcome. Concurrency-cancelled runs and aggregate gate jobs failing due to a cancelled prerequisite compound this, and matrix/shard jobs emit noise per-shard as they complete.

## What changed

Five independently-reviewable commits:

1. **Tag check events with head SHA and recognize cancelled checks** — every `check.*` event payload now carries the `headSha` it was observed on, and a GitHub check-run conclusion of `CANCELLED` is now mapped to a new `check.cancelled` kind (low priority) instead of falling through to `check.created`.

2. **Reconcile check.failed against current HEAD, rewrite reminder text** — `buildReminderBatch` looks up the PR's current snapshot head SHA and partitions `check.failed`/`check.cancelled` events into live (matches HEAD, or no headSha recorded — backward compatible) vs superseded (stale). Superseded events are excluded from the actionable-blocker check and coalesced into one summary line per old commit instead of repeating individually. Reminder text is also tightened: the header states the qualified PR + HEAD SHA once, live changes and superseded history render as separate sections, and the action-required line is shorter.

3. **Suppress cancellation churn from races and aggregate-gate failures** — handles two sources of noise from concurrent runs on the *same* commit (a push and a label-triggered run racing): checks are grouped by name per tick so an active rerun always wins over a stale fail/cancelled duplicate, and a failing check is *conditionally* downgraded to `check.cancelled` when a sibling in the same workflow was cancelled this tick.

4. **Coalesce matrix/shard checks: quiet on green, loud on first red** — matrix jobs are recognized by stripping a trailing `(...)`/`[...]` segment from the check name. A failing shard always fires immediately and uncondensed. A shard succeeding is suppressed while siblings are still running, suppressed again if a sibling already failed, and rolled up into one "N/N shards succeeded" event only once the whole job finishes clean.

5. **Fix false-negative in aggregate-gate cancellation heuristic** — an independent review caught that commit 3's downgrade, as originally written, keyed only on workflow name and could mask a *real* failure: either a matrix shard failing for a genuine reason (fail-fast routinely cancels its siblings as a normal consequence) or an unrelated job failing for a genuine reason while something else in the same workflow was cancelled for an unrelated one. This commit narrows the heuristic to require the failing check's own name to look like an aggregate gate (`/\b(gate|required|fail[- ]?if|overall|rollup)\b/i`) **and** that it is not itself part of a matrix group — so a real matrix-shard failure is never eligible for the downgrade regardless of naming. Two regression tests reproduce the exact false-negative scenarios and assert they correctly stay `check.failed`/high priority.

## Testing

- `bun run --bun tsc -p tsconfig.json --noEmit` — clean
- `bun run test` — 264/264 passing (40 new tests added across the five commits)
- Reviewed by an independent Sonnet agent with no prior context on this branch, adversarially checking for logic bugs (esp. false negatives that could hide a real CI failure), backward compatibility, and test quality. Its one blocker finding is what commit 5 fixes; smaller nits (misleading comment, a documented edge case in cross-tick matrix-group stability, and a minor query-ordering inefficiency) are also addressed in commit 5.

_(Drafted by Jacob's coding agent on his behalf)_
