### PR TITLE
Wait for transient SQLite locks

### DIFF
--- a/src/daemon/persistence/store.test.ts
+++ b/src/daemon/persistence/store.test.ts
@@ -1,10 +1,12 @@
 import assert from "node:assert/strict"
+import { spawn } from "node:child_process"
+import { once } from "node:events"
 import fs from "node:fs"
 import os from "node:os"
 import path from "node:path"
 import { DatabaseSync } from "node:sqlite"
 import { afterEach, describe, test } from "node:test"
-import { PREMIND_DATABASE_BUSY_TIMEOUT_MS, PREMIND_PR_STREAM_RETENTION_MS } from "../../shared/constants.ts"
+import { PREMIND_PR_STREAM_RETENTION_MS } from "../../shared/constants.ts"
 import { StateStore } from "./store.ts"
 import type { PullRequestSnapshot } from "../github/types.ts"
 import { diffSnapshot } from "../github/diff.ts"
@@ -52,15 +54,41 @@ afterEach(() => {
 })
 
 describe("StateStore", () => {
-  test("configures a busy timeout for concurrent database access", () => {
-    const store = createStore()
+  test("waits for a transient external database lock", { timeout: 5_000 }, async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "premind-store-lock-test-"))
+    const dbPath = path.join(dir, "premind.db")
+    tempPaths.push(dir)
+
+    const initialStore = new StateStore(dbPath)
+    initialStore.close()
+
+    const lockHolder = spawn(
+      process.execPath,
+      [
+        "-e",
+        `
+          const { DatabaseSync } = require("node:sqlite");
+          const db = new DatabaseSync(process.argv[1]);
+          db.exec("BEGIN EXCLUSIVE");
+          process.stdout.write("locked\\n");
+          setTimeout(() => { db.exec("COMMIT"); db.close(); }, 100);
+        `,
+        dbPath,
+      ],
+      { stdio: ["ignore", "pipe", "inherit"] },
+    )
+    await once(lockHolder.stdout!, "data")
+
+    const startedAt = Date.now()
+    const store = new StateStore(dbPath)
+    const elapsedMs = Date.now() - startedAt
     try {
-      const db = (store as unknown as { db: DatabaseSync }).db
-      const timeout = db.prepare("PRAGMA busy_timeout").get() as { timeout: number }
-      assert.equal(timeout.timeout, PREMIND_DATABASE_BUSY_TIMEOUT_MS)
+      assert.ok(elapsedMs >= 75, `expected the store to wait for the lock, waited ${elapsedMs}ms`)
     } finally {
       store.close()
     }
+    const [exitCode] = await once(lockHolder, "exit")
+    assert.equal(exitCode, 0)
   })
 
   for (const scenario of [

--- a/src/daemon/persistence/store.test.ts
+++ b/src/daemon/persistence/store.test.ts
@@ -4,7 +4,7 @@ import os from "node:os"
 import path from "node:path"
 import { DatabaseSync } from "node:sqlite"
 import { afterEach, describe, test } from "node:test"
-import { PREMIND_PR_STREAM_RETENTION_MS } from "../../shared/constants.ts"
+import { PREMIND_DATABASE_BUSY_TIMEOUT_MS, PREMIND_PR_STREAM_RETENTION_MS } from "../../shared/constants.ts"
 import { StateStore } from "./store.ts"
 import type { PullRequestSnapshot } from "../github/types.ts"
 import { diffSnapshot } from "../github/diff.ts"
@@ -52,6 +52,17 @@ afterEach(() => {
 })
 
 describe("StateStore", () => {
+  test("configures a busy timeout for concurrent database access", () => {
+    const store = createStore()
+    try {
+      const db = (store as unknown as { db: DatabaseSync }).db
+      const timeout = db.prepare("PRAGMA busy_timeout").get() as { timeout: number }
+      assert.equal(timeout.timeout, PREMIND_DATABASE_BUSY_TIMEOUT_MS)
+    } finally {
+      store.close()
+    }
+  })
+
   for (const scenario of [
     { name: "initial failing check", failing: true, conflict: false, manual: false, stale: false },
     { name: "initial conflict", failing: false, conflict: true, manual: false, stale: false },

--- a/src/daemon/persistence/store.ts
+++ b/src/daemon/persistence/store.ts
@@ -5,6 +5,7 @@ import { randomUUID } from "node:crypto";
 import {
 	PREMIND_CLIENT_LEASE_TTL_MS,
 	PREMIND_DB_PATH,
+	PREMIND_DATABASE_BUSY_TIMEOUT_MS,
 	PREMIND_PR_STREAM_RETENTION_MS,
 	PREMIND_STATE_DIR,
 	PREMIND_SUBSCRIPTION_RETENTION_MS,
@@ -138,6 +139,7 @@ export class StateStore {
 		fs.mkdirSync(path.dirname(dbPath), { recursive: true });
 		fs.mkdirSync(PREMIND_STATE_DIR, { recursive: true });
 		this.db = new DatabaseSync(dbPath);
+		this.db.exec(`PRAGMA busy_timeout = ${PREMIND_DATABASE_BUSY_TIMEOUT_MS}`);
 		this.db.exec("PRAGMA journal_mode = WAL");
 		this.db.exec("PRAGMA foreign_keys = ON");
 		this.migrate();

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -8,6 +8,7 @@ export const PREMIND_STATE_DIR =
     ? path.join(os.homedir(), "Library", "Application Support", "premind")
     : path.join(process.env.XDG_STATE_HOME ?? path.join(os.homedir(), ".local", "state"), "premind")
 export const PREMIND_DB_PATH = path.join(PREMIND_STATE_DIR, "premind.db")
+export const PREMIND_DATABASE_BUSY_TIMEOUT_MS = 5_000
 export const PREMIND_EVENT_DETAIL_DIR = path.join(PREMIND_STATE_DIR, "event-details")
 export const PREMIND_CLIENT_HEARTBEAT_MS = 10_000
 export const PREMIND_CLIENT_LEASE_TTL_MS = 30_000


### PR DESCRIPTION
## Summary
- configure a five-second SQLite busy timeout before WAL initialization
- add a cross-process regression test that holds an exclusive SQLite lock, then verifies `StateStore` waits and opens successfully

## Testing
- Red: removing `busy_timeout` causes the regression to fail with `ERR_SQLITE_ERROR: database is locked`
- Green: `node --import tsx --test --test-name-pattern='waits for a transient external database lock' src/daemon/persistence/store.test.ts`
- `bun run check`

_(Drafted by Jacob's coding agent on his behalf)_