### PR TITLE
Harden Claude hook reliability

### DIFF
--- a/plugin-claude/bin/lib.mjs
+++ b/plugin-claude/bin/lib.mjs
@@ -33,11 +33,12 @@ export const request = (
     const connection = net.createConnection(socket);
     let buffer = "";
     let settled = false;
+    let deadline;
 
     const finish = (error, result) => {
       if (settled) return;
       settled = true;
-      connection.setTimeout(0);
+      clearTimeout(deadline);
       if (error) {
         connection.destroy();
         reject(error);
@@ -47,11 +48,11 @@ export const request = (
     };
 
     connection.setEncoding("utf8");
-    connection.setTimeout(timeoutMs);
-    connection.once("error", (error) => finish(error));
-    connection.once("timeout", () =>
-      finish(new Error(`premind daemon request timed out after ${timeoutMs}ms`)),
+    deadline = setTimeout(
+      () => finish(new Error(`premind daemon request timed out after ${timeoutMs}ms`)),
+      timeoutMs,
     );
+    connection.once("error", (error) => finish(error));
     connection.once("end", () =>
       finish(new Error("premind daemon closed the connection without responding")),
     );

--- a/plugin-claude/bin/lib.mjs
+++ b/plugin-claude/bin/lib.mjs
@@ -21,12 +21,43 @@ export const readHookEvent = async (input = process.stdin) => {
   }
 };
 
-export const request = (type, payload, socket = socketPath) =>
+export const IPC_REQUEST_TIMEOUT_MS = 2_000;
+
+export const request = (
+  type,
+  payload,
+  socket = socketPath,
+  timeoutMs = IPC_REQUEST_TIMEOUT_MS,
+) =>
   new Promise((resolve, reject) => {
     const connection = net.createConnection(socket);
     let buffer = "";
+    let settled = false;
+
+    const finish = (error, result) => {
+      if (settled) return;
+      settled = true;
+      connection.setTimeout(0);
+      if (error) {
+        connection.destroy();
+        reject(error);
+      } else {
+        resolve(result);
+      }
+    };
+
     connection.setEncoding("utf8");
-    connection.once("error", reject);
+    connection.setTimeout(timeoutMs);
+    connection.once("error", (error) => finish(error));
+    connection.once("timeout", () =>
+      finish(new Error(`premind daemon request timed out after ${timeoutMs}ms`)),
+    );
+    connection.once("end", () =>
+      finish(new Error("premind daemon closed the connection without responding")),
+    );
+    connection.once("close", () =>
+      finish(new Error("premind daemon closed the connection without responding")),
+    );
     connection.once("connect", () =>
       connection.write(
         `${JSON.stringify({ type, protocolVersion, payload })}\n`,
@@ -43,13 +74,12 @@ export const request = (type, payload, socket = socketPath) =>
           throw new Error(
             `${response.error?.code ?? "IPC_ERROR"}: ${response.error?.message ?? "request failed"}`,
           );
-        resolve(response.result);
+        finish(undefined, response.result);
       } catch (error) {
-        reject(error);
+        finish(error);
       }
     });
   });
-
 const repositoryFromRemote = (remote) => {
   const match = remote
     .trim()

--- a/plugin-claude/test/hooks.test.mjs
+++ b/plugin-claude/test/hooks.test.mjs
@@ -29,8 +29,12 @@ test("request deadline is not extended by an incomplete response", async () => {
   const socket = path.join(os.tmpdir(), `d-${process.pid}-${Date.now()}.sock`);
   const server = net.createServer((connection) => {
     connection.resume();
-    const drip = setInterval(() => connection.write("{"), 5);
-    connection.once("close", () => clearInterval(drip));
+    const stopDripping = () => clearInterval(drip);
+    const drip = setInterval(() => {
+      if (!connection.destroyed && connection.writable) connection.write("{");
+    }, 5);
+    connection.once("error", stopDripping);
+    connection.once("close", stopDripping);
   });
   await new Promise((resolve, reject) => {
     server.once("error", reject);

--- a/plugin-claude/test/hooks.test.mjs
+++ b/plugin-claude/test/hooks.test.mjs
@@ -1,6 +1,30 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
-import { getBoundClaudeSessionId, handleHook } from "../bin/lib.mjs";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+import { getBoundClaudeSessionId, handleHook, request } from "../bin/lib.mjs";
+
+test("request rejects when a connected daemon does not respond", async () => {
+  const socket = path.join(os.tmpdir(), `premind-hook-test-${process.pid}-${Date.now()}.sock`);
+  const server = net.createServer(() => {});
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(socket, resolve);
+  });
+
+  try {
+    await assert.rejects(
+      request("debugStatus", {}, socket, 20),
+      /timed out after 20ms/,
+    );
+  } finally {
+    await new Promise((resolve, reject) =>
+      server.close((error) => (error ? reject(error) : resolve())),
+    );
+  }
+});
+
 
 test("Stop atomically claims a reminder and returns additionalContext without confirming it", async () => {
   const calls = [];

--- a/plugin-claude/test/hooks.test.mjs
+++ b/plugin-claude/test/hooks.test.mjs
@@ -7,7 +7,7 @@ import { getBoundClaudeSessionId, handleHook, request } from "../bin/lib.mjs";
 
 test("request rejects when a connected daemon does not respond", async () => {
   const socket = path.join(os.tmpdir(), `premind-hook-test-${process.pid}-${Date.now()}.sock`);
-  const server = net.createServer(() => {});
+  const server = net.createServer((connection) => connection.resume());
   await new Promise((resolve, reject) => {
     server.once("error", reject);
     server.listen(socket, resolve);
@@ -17,6 +17,30 @@ test("request rejects when a connected daemon does not respond", async () => {
     await assert.rejects(
       request("debugStatus", {}, socket, 20),
       /timed out after 20ms/,
+    );
+  } finally {
+    await new Promise((resolve, reject) =>
+      server.close((error) => (error ? reject(error) : resolve())),
+    );
+  }
+});
+
+test("request deadline is not extended by an incomplete response", async () => {
+  const socket = path.join(os.tmpdir(), `premind-hook-drip-${process.pid}-${Date.now()}.sock`);
+  const server = net.createServer((connection) => {
+    connection.resume();
+    const drip = setInterval(() => connection.write("{"), 5);
+    connection.once("close", () => clearInterval(drip));
+  });
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(socket, resolve);
+  });
+
+  try {
+    await assert.rejects(
+      request("debugStatus", {}, socket, 30),
+      /timed out after 30ms/,
     );
   } finally {
     await new Promise((resolve, reject) =>

--- a/plugin-claude/test/hooks.test.mjs
+++ b/plugin-claude/test/hooks.test.mjs
@@ -6,7 +6,7 @@ import path from "node:path";
 import { getBoundClaudeSessionId, handleHook, request } from "../bin/lib.mjs";
 
 test("request rejects when a connected daemon does not respond", async () => {
-  const socket = path.join(os.tmpdir(), `premind-hook-test-${process.pid}-${Date.now()}.sock`);
+  const socket = path.join(os.tmpdir(), `p-${process.pid}-${Date.now()}.sock`);
   const server = net.createServer((connection) => connection.resume());
   await new Promise((resolve, reject) => {
     server.once("error", reject);
@@ -26,7 +26,7 @@ test("request rejects when a connected daemon does not respond", async () => {
 });
 
 test("request deadline is not extended by an incomplete response", async () => {
-  const socket = path.join(os.tmpdir(), `premind-hook-drip-${process.pid}-${Date.now()}.sock`);
+  const socket = path.join(os.tmpdir(), `d-${process.pid}-${Date.now()}.sock`);
   const server = net.createServer((connection) => {
     connection.resume();
     const drip = setInterval(() => connection.write("{"), 5);

--- a/src/plugin-opencode/index.ts
+++ b/src/plugin-opencode/index.ts
@@ -1,7 +1,7 @@
 import { tool, type Plugin } from "@opencode-ai/plugin"
 import { PREMIND_CLIENT_HEARTBEAT_MS, PREMIND_IDLE_DELIVERY_THRESHOLD_MS } from "../shared/constants.ts"
 import type { PremindConfig } from "../shared/schema.ts"
-import { ensureUserConfigTemplate, getDefaultUserConfigPath, loadPremindConfig } from "../shared/config-loader.ts"
+import { ensureUserConfigTemplate, getDefaultUserConfigPath, getLegacyUserConfigPath, loadPremindConfig } from "../shared/config-loader.ts"
 import { PremindDaemonClient } from "./daemon-client.ts"
 import { renderPremindStatus } from "./commands.ts"
 import { getPluginRuntimeStatePath, readPluginInstances, readPluginRuntimeState, registerPluginInstance, writePluginRuntimeState } from "./debug-state.ts"
@@ -131,7 +131,11 @@ export const createPremindPlugin = (dependencies: PremindPluginDependencies = {}
     const underNodeTestRunner = typeof process.env.NODE_TEST_CONTEXT === "string"
     if (!underNodeTestRunner) {
       const ensureTemplate = dependencies.ensureConfigTemplate ?? (() => {
-        ensureUserConfigTemplate(getDefaultUserConfigPath())
+        ensureUserConfigTemplate(
+          getDefaultUserConfigPath(),
+          undefined,
+          getLegacyUserConfigPath(),
+        )
       })
       ensureTemplate()
     }

--- a/src/shared/config-loader.test.ts
+++ b/src/shared/config-loader.test.ts
@@ -272,6 +272,17 @@ describe("ensureUserConfigTemplate", () => {
     assert.equal(cfg.idleDeliveryThresholdMs, PREMIND_IDLE_DELIVERY_THRESHOLD_MS)
   })
 
+  test("does not create a primary template when a legacy config exists", () => {
+    const primary = path.join(scratch, "premind", "premind.jsonc")
+    const legacy = path.join(scratch, "opencode", "premind.jsonc")
+    fs.mkdirSync(path.dirname(legacy), { recursive: true })
+    fs.writeFileSync(legacy, '{"idleDeliveryThresholdMs": 30000}', "utf8")
+
+    assert.equal(ensureUserConfigTemplate(primary, undefined, legacy), "exists")
+    assert.ok(!fs.existsSync(primary))
+  })
+
+
   test("does not overwrite an existing file", () => {
     const target = path.join(scratch, "premind.jsonc")
     fs.writeFileSync(target, '{"idleDeliveryThresholdMs": 30000}', "utf8")


### PR DESCRIPTION
## Summary
- bound Claude daemon IPC requests with an absolute deadline and close handling
- preserve legacy OpenCode config during template initialization
- add regressions for stalled, slow-drip IPC responses and legacy config preservation

## Validation
- `npm test` (362 passing)
- `bun run check`
- independent maintainability review

_(Drafted by Jacob's coding agent on his behalf)